### PR TITLE
MOSIP-39964 - Removed the unadded testscript form testng

### DIFF
--- a/uitest-pmprevamp/src/main/resources/testngFile/testng.xml
+++ b/uitest-pmprevamp/src/main/resources/testngFile/testng.xml
@@ -12,7 +12,6 @@
 			<class name="io.mosip.testrig.pmprevampui.testcase.CreateApiKey" />
 			<class name="io.mosip.testrig.pmprevampui.testcase.DeviceProviderTest" />
 			<class name="io.mosip.testrig.pmprevampui.testcase.FTMDeviceTest" />
-			<class name="io.mosip.testrig.pmprevampui.testcase.PartnerManagerPoliciesTest" />
 		</classes>
 		
 	</test>


### PR DESCRIPTION
MOSIP-39964 - Removed the unadded testscript form testng