### PR TITLE
[MOSIP-44442]: Integration, API Key for AUTH_PARTNER: POST /partners/{partnerId}/policies/{policyId}/api-keys

### DIFF
--- a/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
+++ b/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
@@ -94,7 +94,7 @@ function GenerateApiKey() {
           );
           setPartnerType(getPartnerTypeDescription("AUTH_PARTNER", t));
           setPolicyGroupName(selectedPartner.policyGroupName);
-          setPoliciesDropdownData(createDropdownData('policyName', 'policyDescription', false, activePolicies, t));
+          setPoliciesDropdownData(createDropdownData('policyId', 'policyDescription', false, activePolicies, t));
         }
       };
 
@@ -185,11 +185,10 @@ function GenerateApiKey() {
         setErrorMsg("");
         setDataLoaded(false);
         let request = createRequest({
-            policyName: policyName,
-            label: trimAndReplace(nameLabel)
-        });
+            apiKeyName: trimAndReplace(nameLabel)
+        }, 'mosip.pms.generate.api.key.post', true);
         try {
-            const response = await HttpService.patch(getPartnerManagerUrl(`/partners/${partnerId}/generate/apikey`, process.env.NODE_ENV), request, {
+            const response = await HttpService.post(getPartnerManagerUrl(`/partners/${partnerId}/policies/${policyName}/api-keys`, process.env.NODE_ENV), request, {
                 headers: {
                     'Content-Type': 'application/json'
                 }

--- a/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
+++ b/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
@@ -96,7 +96,13 @@ function GenerateApiKey() {
           );
           setPartnerType(getPartnerTypeDescription("AUTH_PARTNER", t));
           setPolicyGroupName(selectedPartner.policyGroupName);
-          setPoliciesDropdownData(createDropdownData('policyId', 'policyDescription', false, activePolicies, t));
+          setPoliciesDropdownData(
+            activePolicies.map(item => ({
+                fieldCode: item.policyName,
+                fieldValue: item.policyId,
+                fieldDescription: item.policyDescription
+            }))
+          );
         }
       };
 
@@ -105,11 +111,7 @@ function GenerateApiKey() {
         const selectedPolicy = policyRequestsData.find(
             item => item.policyId === selectedValue && item.partnerId === partnerId
         );
-        setPolicyName(
-            selectedPolicy
-                ? (selectedPolicy.policyName || selectedPolicy.policyDescription || "")
-                : ""
-        );
+        setPolicyName(selectedPolicy ? selectedPolicy.policyName : "");
     };
 
     const onChangeNameLabel = (value) => {

--- a/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
+++ b/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
@@ -96,22 +96,16 @@ function GenerateApiKey() {
           );
           setPartnerType(getPartnerTypeDescription("AUTH_PARTNER", t));
           setPolicyGroupName(selectedPartner.policyGroupName);
-          setPoliciesDropdownData(
-            activePolicies.map(item => ({
-                fieldCode: item.policyName,
-                fieldValue: item.policyId,
-                fieldDescription: item.policyDescription
-            }))
-          );
+          setPoliciesDropdownData(createDropdownData('policyName', 'policyDescription', false, activePolicies, t));
         }
       };
 
     const onChangePolicyName = (fieldName, selectedValue) => {
-        setPolicyId(selectedValue);
+        setPolicyName(selectedValue);
         const selectedPolicy = policyRequestsData.find(
-            item => item.policyId === selectedValue && item.partnerId === partnerId
+            item => item.policyName === selectedValue && item.partnerId === partnerId
         );
-        setPolicyName(selectedPolicy ? selectedPolicy.policyName : "");
+        setPolicyId(selectedPolicy ? selectedPolicy.policyId : "");
     };
 
     const onChangeNameLabel = (value) => {
@@ -312,7 +306,7 @@ function GenerateApiKey() {
                                                         onDropDownChangeEvent={onChangePolicyName}
                                                         fieldNameKey='requestPolicy.policyName*'
                                                         placeHolderKey='generateApiKey.selectedPolicyName'
-                                                        selectedDropdownValue={policyId}
+                                                        selectedDropdownValue={policyName}
                                                         searchKey='commons.search'
                                                         styleSet={styles}
                                                         addInfoIcon={true}

--- a/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
+++ b/pmp-ui-v2/src/pages/partner/authenticationServices/GenerateApiKey.js
@@ -29,6 +29,7 @@ function GenerateApiKey() {
     const [partnerIdDropdownData, setPartnerIdDropdownData] = useState([]);
     const [policiesDropdownData, setPoliciesDropdownData] = useState([]);
     const [partnerId, setPartnerId] = useState("");
+    const [policyId, setPolicyId] = useState("");
     const [policyName, setPolicyName] = useState("");
     const [partnerType, setPartnerType] = useState("");
     const [policyGroupName, setPolicyGroupName] = useState("");
@@ -82,6 +83,7 @@ function GenerateApiKey() {
 
     const onChangePartnerId = async (fieldName, selectedValue) => {
         setPartnerId(selectedValue);
+        setPolicyId("");
         setPolicyName("");
         setPolicyGroupName("");
         setPoliciesDropdownData([]);
@@ -99,7 +101,15 @@ function GenerateApiKey() {
       };
 
     const onChangePolicyName = (fieldName, selectedValue) => {
-        setPolicyName(selectedValue);
+        setPolicyId(selectedValue);
+        const selectedPolicy = policyRequestsData.find(
+            item => item.policyId === selectedValue && item.partnerId === partnerId
+        );
+        setPolicyName(
+            selectedPolicy
+                ? (selectedPolicy.policyName || selectedPolicy.policyDescription || "")
+                : ""
+        );
     };
 
     const onChangeNameLabel = (value) => {
@@ -157,6 +167,7 @@ function GenerateApiKey() {
         setPartnerId("");
         setPartnerType("");
         setPolicyGroupName("");
+        setPolicyId("");
         setPolicyName("");
         setNameLabel("");
         setPoliciesDropdownData([]);
@@ -188,7 +199,7 @@ function GenerateApiKey() {
             apiKeyName: trimAndReplace(nameLabel)
         }, 'mosip.pms.generate.api.key.post', true);
         try {
-            const response = await HttpService.post(getPartnerManagerUrl(`/partners/${partnerId}/policies/${policyName}/api-keys`, process.env.NODE_ENV), request, {
+            const response = await HttpService.post(getPartnerManagerUrl(`/partners/${partnerId}/policies/${policyId}/api-keys`, process.env.NODE_ENV), request, {
                 headers: {
                     'Content-Type': 'application/json'
                 }
@@ -299,7 +310,7 @@ function GenerateApiKey() {
                                                         onDropDownChangeEvent={onChangePolicyName}
                                                         fieldNameKey='requestPolicy.policyName*'
                                                         placeHolderKey='generateApiKey.selectedPolicyName'
-                                                        selectedDropdownValue={policyName}
+                                                        selectedDropdownValue={policyId}
                                                         searchKey='commons.search'
                                                         styleSet={styles}
                                                         addInfoIcon={true}


### PR DESCRIPTION
…olicyId}/api-keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined API key creation: policy selection now binds reliably to the selected policy ID, and the UI shows concise policy labels and descriptions for clearer selection.
* **Bug Fixes**
  * Switching partners fully clears policy selection and related form fields.
  * API key submission now uses the creation flow and sends the API key name as the primary identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->