### PR TITLE
MOSIP-44610  Warning message and certificate fetch success message fix

### DIFF
--- a/pmp-ui-v2/public/i18n/ara.json
+++ b/pmp-ui-v2/public/i18n/ara.json
@@ -260,7 +260,9 @@
         "fileUploadError": "الشهادة التي تم تحميلها ليست بالتنسيق الصحيح. يُسمح فقط بتحميل الشهادات ذات التنسيق .cer أو .pem",
         "unableToUploadCertificate": "غير قادر على تحميل شهادة الشريك",
         "errorWhileUploadingCertificate": "بسبب حدوث خطأ، لم نتمكن من تحميل الشهادة. يرجى المحاولة مرة أخرى.",
-        "errorWhileGettingCertOrgName": "غير قادر على الحصول على اسم منظمة الشهادة"
+        "errorWhileGettingCertOrgName": "غير قادر على الحصول على اسم منظمة الشهادة",
+        "reuploadCertificateWarningMessage": "سيتم إبطال شهادتك الحالية بعد وقت قصير من رفع الشهادة الجديدة. تابع إذا كنت ترغب في المتابعة.",
+        "fetchCertificateSuccessMessage": "لقد نجحنا في جلب الشهادة من النظام المحلي."
     },
     "partnerTypes": {
         "deviceProvider": "مزود الجهاز",

--- a/pmp-ui-v2/public/i18n/eng.json
+++ b/pmp-ui-v2/public/i18n/eng.json
@@ -262,7 +262,9 @@
         "fileUploadError": "The certificate uploaded is not in the correct format. Only certificates having format .cer or .pem is allowed for upload",
         "unableToUploadCertificate": "Unable to upload partner certificate",
         "errorWhileUploadingCertificate": "Due to an error, we were unable to upload the certificate. Please try again.",
-        "errorWhileGettingCertOrgName": "Unable to get the certificate organisation name"
+        "errorWhileGettingCertOrgName": "Unable to get the certificate organisation name",
+        "reuploadCertificateWarningMessage": "Your existing certificate will be revoked soon after you upload new certificate. Continue if you wish to proceed.",
+        "fetchCertificateSuccessMessage": "We have successfully fetched the certificate from local system."
     },
     "partnerTypes": {
         "deviceProvider": "Device Provider",

--- a/pmp-ui-v2/public/i18n/fra.json
+++ b/pmp-ui-v2/public/i18n/fra.json
@@ -260,7 +260,9 @@
         "fileUploadError": "Le certificat téléversé n'est pas au bon format. Seuls les certificats au format .cer ou .pem peuvent être téléversés.",
         "unableToUploadCertificate": "Impossible de téléverser le certificat du partenaire",
         "errorWhileUploadingCertificate": "En raison d'une erreur, nous n'avons pas pu téléverser le certificat. Veuillez réessayer.",
-        "errorWhileGettingCertOrgName": "Impossible d'obtenir le nom de l'organisation du certificat"
+        "errorWhileGettingCertOrgName": "Impossible d'obtenir le nom de l'organisation du certificat",
+        "reuploadCertificateWarningMessage": "Votre certificat existant sera révoqué peu après le téléversement du nouveau certificat. Continuez si vous souhaitez poursuivre.",
+        "fetchCertificateSuccessMessage": "Nous avons récupéré avec succès le certificat depuis le système local."
     },
     "partnerTypes": {
         "deviceProvider": "Fournisseur d'appareil",

--- a/pmp-ui-v2/src/pages/partner/certificates/UploadCertificate.js
+++ b/pmp-ui-v2/src/pages/partner/certificates/UploadCertificate.js
@@ -19,6 +19,7 @@ function UploadCertificate({ closePopup, popupData, request }) {
     const [uploading, setUploading] = useState(false);
     const [fileName, setFileName] = useState('');
     const [uploadSuccess, setUploadSuccess] = useState(false);
+    const [certificateFetchSuccess, setCertificateFetchSuccess] = useState(false);
     const [uploadFailure, setUploadFailure] = useState(false);
     const [errorCode, setErrorCode] = useState("");
     const [errorMsg, setErrorMsg] = useState("");
@@ -50,6 +51,7 @@ function UploadCertificate({ closePopup, popupData, request }) {
         setSuccessMsg("");
         setErrorCode("");
         setErrorMsg("");
+        setCertificateFetchSuccess(false);
         if (uploadSuccess) {
             closePopup(true, 'close');
         } else {
@@ -149,11 +151,13 @@ function UploadCertificate({ closePopup, popupData, request }) {
     const cancelUpload = () => {
         setFileName("");
         setUploading(false);
+        setCertificateFetchSuccess(false);
     };
     const removeUpload = () => {
         setFileName("");
         setUploadSuccess(false);
         setUploading(false);
+        setCertificateFetchSuccess(false);
     };
     const cancelErrorMsg = () => {
         setErrorMsg("");
@@ -165,6 +169,7 @@ function UploadCertificate({ closePopup, popupData, request }) {
     const handleFileChange = (event) => {
         setErrorMsg("");
         setErrorCode("");
+        setCertificateFetchSuccess(false);
         const file = event.target.files[0];
         if (file) {
             const fileName = file.name;
@@ -178,7 +183,8 @@ function UploadCertificate({ closePopup, popupData, request }) {
                     setFileName(fileName);
                     setCertificateData(fileData);
                     setTimeout(() => {
-                        setUploading(false);
+                    setUploading(false);
+                    setCertificateFetchSuccess(true);
                     }, 2000);
                 }
                 reader.readAsText(file);
@@ -247,6 +253,14 @@ function UploadCertificate({ closePopup, popupData, request }) {
                                 {uploadSuccess && successMsg && (
                                     <SuccessMessage id='upload_certificate_success_msg' successMsg={successMsg} clickOnCancel={cancelSuccessMsg} customStyle={successcustomStyle} />
                                 )}
+                                {!uploadSuccess && certificateFetchSuccess && (
+                                    <SuccessMessage
+                                        id='fetch_certificate_success_msg'
+                                        successMsg={t('uploadCertificate.fetchCertificateSuccessMessage')}
+                                        clickOnCancel={() => setCertificateFetchSuccess(false)}
+                                        customStyle={successcustomStyle}
+                                    />
+                                )}
                                 <div className="px-[4%] py-[2%]">
                                     <form>
                                         <div className="mb-2">
@@ -260,6 +274,11 @@ function UploadCertificate({ closePopup, popupData, request }) {
                                                 value={partnerDomainType} disabled />
                                         </div>
                                     </form>
+                                    {popupData.isCertificateAvailable && (
+                                        <p id='upload_certificate_warning_message' className="text-sm text-[#D17B00] font-medium mt-1 mb-2">
+                                            {t('uploadCertificate.reuploadCertificateWarningMessage')}
+                                        </p>
+                                    )}
                                     <div className={`flex items-center p-2 justify-center w-full min-h-36 h-fit border-2 border-[#9CB2E0] rounded-xl bg-[#F8FBFF] bg-opacity-100 text-center  ${uploadSuccess ? 'pointer-events-none' : 'cursor-pointer'} relative`}>
                                         {uploading && (
                                             <div className={`flex flex-col items-center justify-center mb-1 cursor-pointer`}>


### PR DESCRIPTION
[MOSIP-44610]

[MOSIP-44610]: https://mosip.atlassian.net/browse/MOSIP-44610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning notification when re-uploading certificates to inform users that their current certificate will be revoked after uploading a new one.
  * Added success confirmation message that appears when certificates are successfully fetched from the local system.
  * Enhanced certificate upload experience with improved user feedback and confirmation messaging across multiple languages (Arabic, English, French).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->