### PR TITLE
MOSIP-44609  Title and success message are not matching as per the story in Upload Root of Trust Certificate screen

### DIFF
--- a/pmp-ui-v2/public/i18n/ara.json
+++ b/pmp-ui-v2/public/i18n/ara.json
@@ -908,6 +908,7 @@
     },
     "uploadTrustCertificate": {
         "uploadTrustCertificate": "رفع شهادة الثقة",
+        "uploadRootOfTrustCertificateHeading": "رفع شهادة جذر الثقة",
         "description": "الرجاء تحديد نطاق الشريك وتحميل شهادة CA الجذرية / CA المتوسطة.",
         "uploadSectionDescription": "الرجاء النقر لتحديد شهادة CA الجذرية / CA المتوسطة",
         "uploadingCertMessage": "نحن نقوم بتحميل شهادتك",

--- a/pmp-ui-v2/public/i18n/ara.json
+++ b/pmp-ui-v2/public/i18n/ara.json
@@ -914,7 +914,7 @@
         "uploadingCertMessage": "نحن نقوم بتحميل شهادتك",
         "partnerDomain": "مجال الشريك",
         "dropdownPlaceholder": "حدد مجال الشريك",
-        "successMsg": "تم تحميل شهادة الثقة لـ {{partnerDomain}} بنجاح!",
+        "successMsg": "تم تحميل شهادة جذر الثقة لـ {{partnerDomain}} بنجاح!",
         "downloadRootCertSuccessMsg": "تم تنزيل شهادة الجذر CA بنجاح",
         "downloadIntermediateCertSuccessMsg": "تم تنزيل سلسلة شهادات الثقة لشهادة CA الوسيطة المحددة بنجاح."
     },

--- a/pmp-ui-v2/public/i18n/eng.json
+++ b/pmp-ui-v2/public/i18n/eng.json
@@ -904,12 +904,13 @@
     },
     "uploadTrustCertificate": {
         "uploadTrustCertificate": "Upload Trust Certificate",
+        "uploadRootOfTrustCertificateHeading": "Upload Root of Trust Certificate",
         "description": "Please select the partner domain and upload Root CA / Intermediate CA Certificate.",
         "uploadSectionDescription": "Please tap to select the Root CA / Intermediate CA Certificate",
         "uploadingCertMessage": "We’re uploading your certificate",
         "partnerDomain": "Partner Domain",
         "dropdownPlaceholder": "Select partner domain",
-        "successMsg": "Trust Certificate for {{partnerDomain}} is uploaded successfully!",
+        "successMsg": "Root of Trust certificate for {{partnerDomain}} is uploaded successfully!",
         "downloadRootCertSuccessMsg": "Root CA Certificate is downloaded successfully",
         "downloadIntermediateCertSuccessMsg": "Certificate Chain of Trust for the given Intermediate CA certificate is downloaded successfully."
     },

--- a/pmp-ui-v2/public/i18n/fra.json
+++ b/pmp-ui-v2/public/i18n/fra.json
@@ -908,12 +908,13 @@
     },
     "uploadTrustCertificate": {
         "uploadTrustCertificate": "Téléverser le certificat de confiance",
+        "uploadRootOfTrustCertificateHeading": "Téléverser le certificat racine de confiance",
         "description": "Veuillez sélectionner le domaine partenaire et téléverser le certificat CA racine / CA intermédiaire.",
         "uploadSectionDescription": "Veuillez appuyer pour sélectionner le certificat d'autorité de certification racine / intermédiaire",
         "uploadingCertMessage": "Nous téléversons votre certificat",
         "partnerDomain": "Domaine partenaire",
         "dropdownPlaceholder": "Sélectionnez un domaine partenaire",
-        "successMsg": "Le certificat de confiance pour {{partnerDomain}} a été téléversé avec succès !",
+        "successMsg": "Le certificat racine de confiance pour {{partnerDomain}} a été téléversé avec succès !",
         "downloadRootCertSuccessMsg": "Le certificat de l'autorité de certification racine a été téléchargé avec succès",
         "downloadIntermediateCertSuccessMsg": "La chaîne de certificats de confiance pour le certificat d'autorité de certification intermédiaire donné a été téléchargée avec succès."
     },

--- a/pmp-ui-v2/src/pages/admin/certificates/UploadTrustCertificate.js
+++ b/pmp-ui-v2/src/pages/admin/certificates/UploadTrustCertificate.js
@@ -218,7 +218,7 @@ function UploadTrustCertificate() {
                                 {!uploadSuccess ?
                                     <div className="w-[100%] bg-snow-white mt-[1.5%] rounded-lg shadow-md p-1">
                                         <div className={`flex-col text-center text-base my-5`}>
-                                            <h1 id='upload_trust_certificate_header' className='font-semibold text-dark-blue'>{t('uploadTrustCertificate.uploadTrustCertificate')}</h1>
+                                            <h1 id='upload_trust_certificate_header' className='font-semibold text-dark-blue'>{t('uploadTrustCertificate.uploadRootOfTrustCertificateHeading')}</h1>
                                             <p id='upload_trust_certificate_description' className='text-light-gray py-1'>{t('uploadTrustCertificate.description')}</p>
                                         </div>
                                         <div className='flex-col w-full'>


### PR DESCRIPTION
[MOSIP-44609]

[MOSIP-44609]: https://mosip.atlassian.net/browse/MOSIP-44609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated certificate upload interface labels in English, French, and Arabic to specify "Root of Trust Certificate".
  * Added a new heading for the upload dialog: "Upload Root of Trust Certificate" (localized).
  * Clarified success confirmation messages to explicitly reference "Root of Trust Certificate" across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->