### PR TITLE
MOSIP-44631 & MOSIP-44635 Incorrect Partner ID tooltip text displayed on Request Policy screen.Incorrect error message displayed in french language when uploading future-dated certificate

### DIFF
--- a/pmp-ui-v2/public/i18n/eng.json
+++ b/pmp-ui-v2/public/i18n/eng.json
@@ -352,7 +352,7 @@
         "errorInMapPolicy": "While requesting a policy, we have encountered with an error",
         "policySuccessHeader": "Policy Request has been submitted successfully!",
         "policySuccessMsg": "Policy request process has been successfully submitted. Approval is pending with admin.",
-        "info": "Only those partner IDs whose partner certificate is uploaded is available in the dropdown. If you don't find your partner ID, please upload partner certificate first",
+        "info": "Only those partner IDs whose partner certificate is uploaded are available in the dropdown. If you don't find your partner ID, please upload partner certificate first.",
         "mispPartnerInfo": "Only those MISP partner IDs whose partner certificate is uploaded is available in the dropdown. If you don't find your partner ID, please upload partner certificate first",
         "commentTooLong": "Comments should not allow more than 500 characters.",
         "policyGroupNotAvailable": "No policy group linked to the given Partner ID.",

--- a/pmp-ui-v2/public/i18n/fra.json
+++ b/pmp-ui-v2/public/i18n/fra.json
@@ -1659,7 +1659,7 @@
         "KER-PCM-011": "Domaine partenaire non valide",
         "KER-PCM-018": "Type de certificat non valide",
         "KER-PMS-019": "Aucun certificat CA n'a été trouvé pour l'ID donné.",
-        "KER-PMS-020": "Le téléchargement de certificats périmés n'est pas autorisé.",
+        "KER-PMS-020": "Le téléversement de certificats datés dans le futur n'est pas autorisé.",
         "KER-CRY-003": "Certificat invalide : corruption de fichier possible, falsification ou format non pris en charge. Assurez-vous qu’il est correctement codé en Base64 et réessayez.",
         "PMS_NOTIFICATION_ERROR_001": "Erreur lors de la mise à jour des notifications date et heure.",
         "PMS_NOTIFICATION_ERROR_002": "Horodatage de notification non valide vu.",


### PR DESCRIPTION
[MOSIP-44631] & [MOSIP-44635]

[MOSIP-44631]: https://mosip.atlassian.net/browse/MOSIP-44631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOSIP-44635]: https://mosip.atlassian.net/browse/MOSIP-44635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected English language grammar in partner certificate dropdown instructions for improved clarity.
  * Updated French error message to clarify certificate validation requirements regarding date restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->