### PR TITLE
MOSIP-44649  Username validation fails in Manual Adjudication Partner creation even when using allowed special characters

### DIFF
--- a/pmp-ui-v2/src/utils/AppUtils.js
+++ b/pmp-ui-v2/src/utils/AppUtils.js
@@ -1480,7 +1480,7 @@ export const validateUsernameRegex = (input, setInputError, t) => {
     }
 
     // Check if the rest of the username contains only valid characters
-    const validPattern = /^[\p{L}][\p{L}\p{N}\p{M}._-]*$/u;
+    const validPattern = /^[\p{L}][\p{L}\p{N}\p{M}@#&()\\_'?!":;=_-]*$/u;
 
     if (validPattern.test(input)) {
         setInputError("");


### PR DESCRIPTION
[MOSIP-44649]

[MOSIP-44649]: https://mosip.atlassian.net/browse/MOSIP-44649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usernames now support a wider range of special characters, including @, #, &, parentheses, apostrophes, and punctuation marks, allowing greater flexibility when creating usernames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->