### PR TITLE
[MOSIP-44660] fixed hardcoded CredentialTypes

### DIFF
--- a/pmp-ui-v2/src/pages/partner/credentialServices/MapCredentialType.js
+++ b/pmp-ui-v2/src/pages/partner/credentialServices/MapCredentialType.js
@@ -160,14 +160,17 @@ function MapCredentialType() {
 
         setAllowedCredentialTypes(normalizedCredentialTypes);
       } catch (error) {
+        if (cancelled) return;
         console.error("Error fetching allowed credential types:", error);
+        setAllowedCredentialTypes([]);
+        setErrorMsg(t("mapCredentialType.saveError"));
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (!needsBioFetch) return;

--- a/pmp-ui-v2/src/pages/partner/credentialServices/MapCredentialType.js
+++ b/pmp-ui-v2/src/pages/partner/credentialServices/MapCredentialType.js
@@ -10,8 +10,8 @@ import LoadingIcon from "../../common/LoadingIcon";
 import DropdownComponent from "../../common/fields/DropdownComponent";
 import BlockerPrompt from "../../common/BlockerPrompt";
 import Confirmation from "../../common/Confirmation";
+import { getAppConfig } from "../../../services/ConfigService";
 
-const CREDENTIAL_TYPE_OPTIONS = ["auth", "qrcode", "euin", "reprint", "vercred", "opencrvs"];
 
 /** Same shape checks as PoliciesList / CredentialPartnerPolicyDetails for GET .../bioextractors/{policyId}. */
 function hasMeaningfulBioMapping(item) {
@@ -125,19 +125,49 @@ function MapCredentialType() {
   const [isSubmitClicked, setIsSubmitClicked] = useState(false);
   const [requestPolicySuccess, setRequestPolicySuccess] = useState(false);
   const [confirmationData, setConfirmationData] = useState({});
+  const [allowedCredentialTypes, setAllowedCredentialTypes] = useState([]);
   const isSubmittingRef = useRef(false);
 
   /** First row is placeholder (empty value); no default credential type selected */
   const credentialTypeDropdownData = useMemo(
     () => [
       { fieldCode: t("mapCredentialType.selectCredentialType"), fieldValue: "" },
-      ...CREDENTIAL_TYPE_OPTIONS.map((value) => ({
+      ...allowedCredentialTypes.map((value) => ({
         fieldCode: value,
         fieldValue: value,
       })),
     ],
-    [t]
+    [allowedCredentialTypes, t]
   );
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const appConfig = await getAppConfig();
+        if (cancelled) return;
+
+        const credentialTypes = appConfig?.allowedCredentialTypes;
+        const parsedCredentialTypes = Array.isArray(credentialTypes)
+          ? credentialTypes
+          : typeof credentialTypes === "string"
+            ? credentialTypes.split(",")
+            : [];
+
+        const normalizedCredentialTypes = parsedCredentialTypes
+          .map((value) => String(value || "").trim())
+          .filter(Boolean);
+
+        setAllowedCredentialTypes(normalizedCredentialTypes);
+      } catch (error) {
+        console.error("Error fetching allowed credential types:", error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!needsBioFetch) return;


### PR DESCRIPTION
[MOSIP-44660]

[MOSIP-44660]: https://mosip.atlassian.net/browse/MOSIP-44660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Credential type options in partner credential services are now loaded from app configuration instead of hardcoded values for greater flexibility.

* **Bug Fixes**
  * Dropdown now shows a placeholder until configuration is loaded.
  * Configuration load failures clear options and surface an error message to the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->