### PR TITLE
MOSIP-44314 Placeholder text not displayed properly in create OIDC client and authentication Policy screens

### DIFF
--- a/pmp-ui-v2/src/pages/admin/policyManager/CreatePolicy.js
+++ b/pmp-ui-v2/src/pages/admin/policyManager/CreatePolicy.js
@@ -313,18 +313,27 @@ function CreatePolicy() {
                                                     />
                                                 </div>
                                                 <div className={`flex flex-col w-2/4 ${isLoginLanguageRTL ? "mr-4" : "ml-4"}`}>
-                                                    <TextInputComponent
-                                                        fieldName="policyName"
-                                                        textBoxValue={policyName}
-                                                        onTextChange={onTextChange}
-                                                        fieldNameKey="createPolicy.policyName*"
-                                                        placeHolderKey={policyNamePlaceHolderKey}
-                                                        styleSet={styleSet}
-                                                        id="policy_name_box"
-                                                        maxLength={128}
-                                                    />
-                                                    {invalidPolicyNameError && <span id='create_policy_invalid_policy_name' className="text-sm text-crimson-red font-semibold">{invalidPolicyNameError}</span>}
-                                                </div>
+
+                                            <label className="text-dark-blue text-sm font-semibold mb-1">
+                                                {t('createPolicy.policyName')}<span className="text-crimson-red">*</span>
+                                            </label>
+
+                                            <textarea
+                                                id="policy_name_box"
+                                                value={policyName}
+                                                onChange={(e) => onTextChange("policyName", e.target.value)}
+                                                className="w-full h-[56px] h-auto px-2 py-1 border border-[#C1C1C1] rounded-md text-base text-vulcan bg-white leading-tight focus:outline-none focus:shadow-outline whitespace-pre-wrap break-words resize-none overflow-hidden"
+                                                placeholder={t(policyNamePlaceHolderKey)}
+                                                maxLength={128}
+                                            />
+
+                                            {invalidPolicyNameError && (
+                                                <span className="text-sm text-crimson-red font-semibold">
+                                                {invalidPolicyNameError}
+                                                </span>
+                                            )}
+
+                                            </div>
                                             </div>
                                             <div className="flex my-2">
                                                 <div className="flex flex-col w-full">
@@ -336,7 +345,7 @@ function CreatePolicy() {
                                                         ref={policyDescriptionRef}
                                                         value={policyDescription}
                                                         onChange={(e) => handlePolicyDescriptionChange(e)}
-                                                        className="w-full min-h-11 h-11 p-3 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline overflow-x-auto whitespace-pre-wrap no-scrollbar"
+                                                        className="w-full min-h-[80px] h-auto p-3 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline whitespace-pre-wrap break-words resize-none overflow-hidden"
                                                         placeholder={t(policyDescriptionPlaceHolderKey)}
                                                         data-placeholder-id="policy_description_box_placeholder"
                                                         maxLength={256}

--- a/pmp-ui-v2/src/pages/admin/policyManager/CreatePolicy.js
+++ b/pmp-ui-v2/src/pages/admin/policyManager/CreatePolicy.js
@@ -222,7 +222,7 @@ function CreatePolicy() {
     }
 
     const isFormValid = () => {
-        return (selectedPolicyGroup?.name) && policyName && policyDescription.trim() && policyData.trim() && !invalidPolicyNameError && !invalidPolicyDescError;
+        return (selectedPolicyGroup?.name) && policyName.trim() && policyDescription.trim() && policyData.trim() && !invalidPolicyNameError && !invalidPolicyDescError;
     };
 
     const handlePolicyDescriptionChange = (e) => {
@@ -256,7 +256,7 @@ function CreatePolicy() {
 
     const onTextChange = (fieldName, fieldValue) => {
         setPolicyName(fieldValue);
-        validateInputRegex(fieldValue, setInvalidPolicyNameError, t);
+        validateInputRegex(fieldValue.trim(), setInvalidPolicyNameError, t);
     };
 
     const styleSet = {

--- a/pmp-ui-v2/src/pages/partner/authenticationServices/CreateOidcClient.js
+++ b/pmp-ui-v2/src/pages/partner/authenticationServices/CreateOidcClient.js
@@ -917,7 +917,7 @@ function CreateOidcClient() {
                               <div className="flex flex-col w-full">
                                 <label id="create_oidc_logo_url_label" className={`block text-dark-blue text-sm font-semibold mb-1  ${isLoginLanguageRTL ? "mr-1" : "ml-1"}`}>{t('createOidcClient.logoUrl')}<span className="text-crimson-red mx-1">*</span></label>
                                 <input id="create_oidc_logo_url" value={logoUrl} onChange={(e) => handleLogoUrlChange(e.target.value)}
-                                  className="h-10 px-2 py-3 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline w-full break-words"
+                                  className="h-10 px-2 py-3 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline w-full"
                                   placeholder={t('createOidcClient.logoUrlPlaceHolder')}
                                   data-placeholder-id="create_oidc_logo_url_placeholder" />
                                 {invalidLogoUrl && <span id="create_oidc_invalid_logo_url" className="text-sm text-crimson-red font-semibold">{invalidLogoUrl}</span>}

--- a/pmp-ui-v2/src/pages/partner/authenticationServices/CreateOidcClient.js
+++ b/pmp-ui-v2/src/pages/partner/authenticationServices/CreateOidcClient.js
@@ -773,8 +773,7 @@ function CreateOidcClient() {
                               </div>
                               <div className="flex flex-col w-[48%]">
                                 <label id='create_oidc_client_partner_type_label' className={`block text-dark-blue text-sm font-semibold mb-1 ${isLoginLanguageRTL ? "mr-1" : "ml-1"}`}>{t('requestPolicy.partnerType')}<span className="text-crimson-red mx-1">*</span></label>
-                                <button id='create_oidc_client_partner_type_context' disabled className="flex items-center justify-between w-full h-10 px-2 py-2 border border-[#C1C1C1] rounded-md text-base text-vulcan bg-platinum-gray leading-tight focus:outline-none focus:shadow-outline
-                          overflow-x-auto whitespace-nowrap no-scrollbar" type="button">
+                                <button id='create_oidc_client_partner_type_context' disabled className="flex items-start justify-between w-full min-h-10 h-auto px-2 py-2 border border-[#C1C1C1] rounded-md text-base text-vulcan bg-platinum-gray leading-tight focus:outline-none focus:shadow-outline w-full break-words" type="button">
                                   <span className={`w-full break-words ${partnerType ? 'text-dark-blue' : 'text-gray-400'} text-wrap text-start`}>{partnerType || t('commons.partnersHelpText')}</span>
                                   <svg className={`w-3 h-2 ml-3 transform 'rotate-0' text-gray-500 text-base`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
                                     <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 4 4 4-4" />
@@ -785,10 +784,9 @@ function CreateOidcClient() {
                             <div className="flex flex-row justify-between space-x-4 my-2">
                               <div className="flex flex-col w-[48%]">
                                 <label id='create_oidc_client_policy_group_label' className={`block text-dark-blue text-sm font-semibold mb-1 mx-1`}>{t('requestPolicy.policyGroup')}<span className="text-crimson-red mx-1">*</span></label>
-                                <button id='create_oidc_client_policy_group_context' disabled className="flex items-center justify-between w-full h-10 px-2 py-2 border border-[#C1C1C1] rounded-md text-base text-vulcan bg-platinum-gray leading-tight focus:outline-none focus:shadow-outline
-                          overflow-x-auto whitespace-nowrap no-scrollbar" type="button">
-                                  <span className={`${partnerType ? 'text-dark-blue' : 'text-gray-400'}`}>{policyGroupName || t('commons.partnersHelpText')}</span>
-                                  <svg className={`w-3 h-2 transform 'rotate-0' text-gray-500 text-base`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+                                <button id='create_oidc_client_policy_group_context' disabled className="flex items-start justify-between w-full min-h-10 h-auto px-2 py-2 border border-[#C1C1C1] rounded-md text-base text-vulcan bg-platinum-gray leading-tight focus:outline-none focus:shadow-outline w-full break-words" type="button">
+                                  <span className={`w-full break-words ${partnerType ? 'text-dark-blue' : 'text-gray-400'} text-wrap text-start`}>{policyGroupName || t('commons.partnersHelpText')}</span>
+                                  <svg className={`w-3 h-2 ml-3 transform 'rotate-0' text-gray-500 text-base`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
                                     <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 4 4 4-4" />
                                   </svg>
                                 </button>
@@ -908,7 +906,7 @@ function CreateOidcClient() {
                                   <Information infoKey={t('createOidcClient.publicKeyToolTip')} id='public_key_info' />
                                 </label>
                                 <textarea id="create_oidc_public_key" value={publicKey} onChange={(e) => handlePublicKeyChange(e.target.value)}
-                                  className="px-2 py-4 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline overflow-x-auto whitespace-nowrap no-scrollbar"
+                                  className="px-2 py-4 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline w-full break-words"
                                   placeholder={t('createOidcClient.publicKeyPlaceHolder')}
                                   data-placeholder-id="create_oidc_public_key_placeholder">
                                 </textarea>
@@ -919,7 +917,7 @@ function CreateOidcClient() {
                               <div className="flex flex-col w-full">
                                 <label id="create_oidc_logo_url_label" className={`block text-dark-blue text-sm font-semibold mb-1  ${isLoginLanguageRTL ? "mr-1" : "ml-1"}`}>{t('createOidcClient.logoUrl')}<span className="text-crimson-red mx-1">*</span></label>
                                 <input id="create_oidc_logo_url" value={logoUrl} onChange={(e) => handleLogoUrlChange(e.target.value)}
-                                  className="h-10 px-2 py-3 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline overflow-x-auto whitespace-nowrap no-scrollbar"
+                                  className="h-10 px-2 py-3 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline w-full break-words"
                                   placeholder={t('createOidcClient.logoUrlPlaceHolder')}
                                   data-placeholder-id="create_oidc_logo_url_placeholder" />
                                 {invalidLogoUrl && <span id="create_oidc_invalid_logo_url" className="text-sm text-crimson-red font-semibold">{invalidLogoUrl}</span>}
@@ -932,7 +930,7 @@ function CreateOidcClient() {
                                   {t('createOidcClient.redirectUrl')}<span className="text-crimson-red mx-1">*</span>
                                 </label>
                                 {redirectUrls.map((url, index) => (
-                                  <div key={index} className="flex w-full justify-between items-center h-10 px-2 py-2 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline overflow-x-auto whitespace-nowrap no-scrollbar focus:shadow-outline mb-2">
+                                  <div key={index} className="flex w-full justify-between items-center h-10 px-2 py-2 border border-[#707070] rounded-md text-base text-dark-blue bg-white leading-tight focus:outline-none focus:shadow-outline w-full break-words focus:shadow-outline mb-2">
                                     <input
                                       value={url}
                                       onChange={(e) => onChangeRedirectUrl(index, e.target.value)}


### PR DESCRIPTION
[MOSIP-44314]

[MOSIP-44314]: https://mosip.atlassian.net/browse/MOSIP-44314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping and display in policy creation form fields to prevent content overflow.
  * Fixed text overflow issues in authentication configuration fields, allowing proper word wrapping instead of horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->