### PR TITLE
 MOSIP-44999  Additional asterisk (*) symbol displayed for the biometic provider configuration name field

### DIFF
--- a/pmp-ui-v2/public/i18n/eng.json
+++ b/pmp-ui-v2/public/i18n/eng.json
@@ -1759,7 +1759,7 @@
         "mappingSectionTitle": "Map Biometric Extractor Provider Configuration",
         "biometricModality": "Biometric Modality",
         "selectBiometricModality": "Select Biometric Modality",
-        "biometricProviderConfiguration": "Biometric Provider Configuration*",
+        "biometricProviderConfiguration": "Biometric Provider Configuration",
         "selectBiometricProviderConfiguration": "Select a Biometric Provider",
         "autoPopulatedValue": "Auto populated based on configuration selected",
         "addMore": "Add More",


### PR DESCRIPTION
[MOSIP-44999]

[MOSIP-44999]: https://mosip.atlassian.net/browse/MOSIP-44999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ