### PR TITLE
MOSIP-45011 The subtitle 'Policy Name' name is not displayed in the view policy details screen as mentioned in the story

### DIFF
--- a/pmp-ui-v2/src/pages/partner/policies/ViewPolicyDetails.js
+++ b/pmp-ui-v2/src/pages/partner/policies/ViewPolicyDetails.js
@@ -39,9 +39,25 @@ function ViewPolicyDetails() {
     return (
         <>
             <div className={`w-full p-5 bg-anti-flash-white h-full break-words font-inter mb-[2%] ${isLoginLanguageRTL ? "mr-20 ml-1" : "ml-20 mr-1"} overflow-x-scroll`}>
-                <div className="flex justify-between mb-5">
-                    <Title title='viewPolicyDetails.viewPolicyDetails' subTitle='viewPolicyDetails.policySection' backLink='/partnermanagement/policies/policies-list' styleSet={style} />
-                </div>
+                                {isCredentialPartner ? (
+                    <div className="mb-5">
+                        <div className="flex justify-between">
+                            <Title title='viewPolicyDetails.viewPolicyDetails' subTitle='viewPolicyDetails.policySection' backLink='/partnermanagement/policies/policies-list' styleSet={style} />
+                        </div>
+                        <div className={`mt-2 ml-3 ${isLoginLanguageRTL ? "text-right" : "text-left"}`}>
+                            <p id='view_policy_details_policy_name_subtitle' className="text-sm font-semibold text-suva-gray">
+                                {t("viewPolicyDetails.policyName")}
+                            </p>
+                            <p id='view_policy_details_policy_name_value' className="text-base font-semibold text-dark-blue">
+                                {policyDetails?.policyName || '-'}
+                            </p>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex justify-between mb-5">
+                        <Title title='viewPolicyDetails.viewPolicyDetails' subTitle='viewPolicyDetails.policySection' backLink='/partnermanagement/policies/policies-list' styleSet={style} />
+                    </div>
+                )}
                 <div className="bg-snow-white h-fit mt-1 rounded-t-xl shadow-lg ml-3">
                     <div className={`flex-col ${isLoginLanguageRTL ? "pr-8" : "pl-8"} pt-6 pb-5`}>
                         <p id='view_policy_details_policy_id' className="text-lg text-dark-blue mb-3">{t('policies.policyId')}: <span className="font-semibold">{policyDetails.policyId}</span></p>


### PR DESCRIPTION
[MOSIP-45011]

[MOSIP-45011]: https://mosip.atlassian.net/browse/MOSIP-45011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specialized policy header display for credential partners, including a labeled policy name field
  * Maintained existing header behavior for non-credential partner types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/partner-management-portal/pull/1742)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->