### PR TITLE
MOSIP-45012 credential type displayed in the Map credential type screen in not as per the story criteria

### DIFF
--- a/pmp-ui-v2/src/pages/partner/credentialServices/MapCredentialType.js
+++ b/pmp-ui-v2/src/pages/partner/credentialServices/MapCredentialType.js
@@ -159,15 +159,16 @@ function MapCredentialType() {
         const appConfig = await getAppConfig();
         if (cancelled) return;
 
-        const credentialTypes = appConfig?.allowedCredentialTypes;
-        const parsedCredentialTypes = Array.isArray(credentialTypes)
-          ? credentialTypes
-          : typeof credentialTypes === "string"
-            ? credentialTypes.split(",")
-            : [];
+      const credentialTypes =
+        appConfig?.allowedCredentialTypes ??
+        appConfig?.["pmp.allowed.credential.types"] ??
+        "";
 
-        const normalizedCredentialTypes = parsedCredentialTypes
-          .map((value) => String(value || "").trim())
+      const normalizedCredentialTypes =
+        (Array.isArray(credentialTypes)
+          ? credentialTypes
+          : String(credentialTypes).split(","))
+          .map(value => String(value || "").trim())
           .filter(Boolean);
 
         setAllowedCredentialTypes(normalizedCredentialTypes);


### PR DESCRIPTION
[MOSIP-45012]

[MOSIP-45012]: https://mosip.atlassian.net/browse/MOSIP-45012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated credential type configuration initialization to support multiple configuration paths with fallback options and revised parsing logic to more flexibly handle various credential type formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/partner-management-portal/pull/1745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->