### PR TITLE
View Online Verification Partner Policy Request Details #1883

### DIFF
--- a/pmp-ui-v2/src/pages/admin/policyRequests/ViewPolicyRequestDetails.js
+++ b/pmp-ui-v2/src/pages/admin/policyRequests/ViewPolicyRequestDetails.js
@@ -16,6 +16,7 @@ function ViewPolicyRequestDetails() {
     const navigate = useNavigate();
     const [policyRequestDetails, setPolicyRequestDetails] = useState({});
     const [showApproveRejectPopup, setShowApproveRejectPopup] = useState(false);
+    const [isPolicyDetailsLoading, setIsPolicyDetailsLoading] = useState(false);
 
     useEffect(() => {
         const policyRequestData = sessionStorage.getItem('selectedPartnerPolicyRequest');
@@ -34,7 +35,7 @@ function ViewPolicyRequestDetails() {
 
     const isCredentialPartner = (policyRequestDetails?.partnerType ?? '').toString().toUpperCase() === 'CREDENTIAL_PARTNER';
 
-    const [isPolicyDetailsLoading, setIsPolicyDetailsLoading] = useState(false);
+    const isOnlineVerificationPartner = (policyRequestDetails?.partnerType ?? '').toString().toUpperCase() === 'ONLINE_VERIFICATION_PARTNER';
 
     const moveToPolicyRequestsList = () => {
         navigate('/partnermanagement/admin/policy-requests-list');
@@ -172,7 +173,7 @@ function ViewPolicyRequestDetails() {
                                 </p>
                             </div>
                         </div>
-                        {isCredentialPartner && (
+                        {(isCredentialPartner || isOnlineVerificationPartner) && (
                             <>
                                 <hr className="h-px mt-3 w-full bg-gray-200 border-0" />
                                 <div className="py-4">
@@ -183,7 +184,7 @@ function ViewPolicyRequestDetails() {
                                         policyId={policyRequestDetails?.policyId}
                                         requestId={policyRequestDetails?.id ?? ""}
                                         partnerTypeLabel={getPartnerTypeDescription(policyRequestDetails?.partnerType, t) ?? policyRequestDetails?.partnerType ?? '-'}
-                                        enabled={isCredentialPartner}
+                                        enabled={isCredentialPartner || isOnlineVerificationPartner}
                                         variant="view"
                                         onLoadingChange={setIsPolicyDetailsLoading}
                                     />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Policy request details page now supports online verification partners, enabling them to view and access credential policy information alongside credential partners. The interface has been updated to recognize both partner types and display policy details accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->