### PR TITLE
fix: remove invalid NPM_BUILD_TYPE input from sonar-analysis workflow…

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -47,7 +47,6 @@ jobs:
     uses: mosip/kattu/.github/workflows/npm-sonar-analysis.yml@develop
     with:
       SERVICE_LOCATION: pmp-ui-v2
-      NPM_BUILD_TYPE: BOB
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       ORG_KEY: ${{ secrets.ORG_KEY }}


### PR DESCRIPTION
… call

npm-sonar-analysis.yml@develop does not define an NPM_BUILD_TYPE input, causing 'Invalid workflow file' errors. develop branch's push-trigger.yml already omits this input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code analysis workflow configuration.
  * Simplified the analysis job settings by removing an obsolete build option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->