### PR TITLE
MOSIP-40334, MOSIP-38408, MOSIP-38189: Automate API Key expiration da…

### DIFF
--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/kernel/util/ConfigManager.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/kernel/util/ConfigManager.java
@@ -650,14 +650,4 @@ public class ConfigManager {
 	    }
 	}
 
-	public static int getApiKeyExpiryPeriodInDays() {
-		try {
-			return Integer.parseInt(propsKernel.getProperty("apiKeyExpiryPeriodInDays", "0").trim());
-		} catch (NumberFormatException e) {
-			logger.error("Invalid apiKeyExpiryPeriodInDays value in Kernel.properties. Falling back to the "
-					+ "100 year default.");
-			return 0;
-		}
-	}
-
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/kernel/util/ConfigManager.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/kernel/util/ConfigManager.java
@@ -650,4 +650,21 @@ public class ConfigManager {
 	    }
 	}
 
+	/**
+	 * Mirrors the PMS backend property
+	 * {@code mosip.pmp.partner.policy.expiry.period.indays}. Returns 0 when the
+	 * environment leaves it unset, which the backend treats as the 100 year
+	 * default. Set {@code apiKeyExpiryPeriodInDays} in Kernel.properties to match
+	 * the environment under test.
+	 */
+	public static int getApiKeyExpiryPeriodInDays() {
+		try {
+			return Integer.parseInt(propsKernel.getProperty("apiKeyExpiryPeriodInDays", "0").trim());
+		} catch (NumberFormatException e) {
+			logger.error("Invalid apiKeyExpiryPeriodInDays value in Kernel.properties. Falling back to the "
+					+ "100 year default.");
+			return 0;
+		}
+	}
+
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/kernel/util/ConfigManager.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/kernel/util/ConfigManager.java
@@ -650,13 +650,6 @@ public class ConfigManager {
 	    }
 	}
 
-	/**
-	 * Mirrors the PMS backend property
-	 * {@code mosip.pmp.partner.policy.expiry.period.indays}. Returns 0 when the
-	 * environment leaves it unset, which the backend treats as the 100 year
-	 * default. Set {@code apiKeyExpiryPeriodInDays} in Kernel.properties to match
-	 * the environment under test.
-	 */
 	public static int getApiKeyExpiryPeriodInDays() {
 		try {
 			return Integer.parseInt(propsKernel.getProperty("apiKeyExpiryPeriodInDays", "0").trim());

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
@@ -427,6 +427,12 @@ public class ApiKeyPage extends BasePage {
 	@FindBy(id = "api_key_list_item1")
 	private WebElement activatedAdminApiKey;
 
+	@FindBy(id = "apiKeysList.expirationDate_header")
+	private WebElement expirationDateColumnHeader;
+
+	@FindBy(xpath = "//p[starts-with(@id,'api_key_details_') and contains(@id,'_label')]")
+	private List<WebElement> individualViewFieldLabels;
+
 	@FindBy(id = "apiKeyExpiryDateTime_desc_icon")
 	private WebElement apiKeyExpiryDateTime_desc_icon;
 
@@ -437,14 +443,6 @@ public class ApiKeyPage extends BasePage {
 		super(driver);
 	}
 
-	private static final String CREATION_DATE_HEADER_ID = "oidcClientsList.creationDate_header";
-	private static final String EXPIRATION_DATE_HEADER_ID = "apiKeysList.expirationDate_header";
-
-	private static final By EXPIRATION_DATE_HEADER = By.xpath("//*[@id='" + EXPIRATION_DATE_HEADER_ID + "']");
-	private static final By EXPIRATION_DATE_LABEL = By.id("api_key_details_expiration_date_label");
-	private static final By EXPIRATION_DATE_CONTEXT = By.id("api_key_details_expiration_date_context");
-	private static final By API_KEY_DETAILS_TITLE = By.xpath("//h1[text()='View API Key Details']");
-
 	private static final By ADMIN_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[7]");
 	private static final By PARTNER_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_list_item')][1]/td[6]");
 	private static final By ADMIN_CREATED_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[6]");
@@ -454,9 +452,6 @@ public class ApiKeyPage extends BasePage {
 
 	private static final By ADMIN_FIRST_ROW = By.id("api_key_list_item1");
 	private static final By PARTNER_FIRST_ROW = By.id("api_list_item1");
-
-	private static final By INDIVIDUAL_VIEW_LABELS = By
-			.xpath("//p[starts-with(@id,'api_key_details_') and contains(@id,'_label')]");
 
 	private static final String NO_EXPIRY_TEXT = "No Expiry";
 
@@ -1242,12 +1237,12 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	public boolean isExpirationDateHeaderDisplayed() {
-		return isDisplayed(EXPIRATION_DATE_HEADER);
+		return isElementDisplayed(expirationDateColumnHeader);
 	}
 
 	public boolean isExpirationDateHeaderAfterCreationDate() {
-		int creationIndex = getColumnIndex(CREATION_DATE_HEADER_ID);
-		int expirationIndex = getColumnIndex(EXPIRATION_DATE_HEADER_ID);
+		int creationIndex = getColumnIndex("oidcClientsList.creationDate_header");
+		int expirationIndex = getColumnIndex("apiKeysList.expirationDate_header");
 		LogUtil.step("Creation Date column index: " + creationIndex + ", Expiration Date column index: "
 				+ expirationIndex);
 
@@ -1383,14 +1378,14 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	public boolean isApiKeyDetailsExpirationDateLabelDisplayed() {
-		if (isElementDisplayedQuick(EXPIRATION_DATE_LABEL, Duration.ofSeconds(5))) {
+		if (isElementDisplayedQuick(By.id("api_key_details_expiration_date_label"), Duration.ofSeconds(5))) {
 			return true;
 		}
 		return isDisplayed(expirationDateLabelInAdminView());
 	}
 
 	public boolean isApiKeyDetailsExpirationDateContextDisplayed() {
-		if (isElementDisplayedQuick(EXPIRATION_DATE_CONTEXT, Duration.ofSeconds(5))) {
+		if (isElementDisplayedQuick(By.id("api_key_details_expiration_date_context"), Duration.ofSeconds(5))) {
 			return true;
 		}
 		return isDisplayed(expirationDateContextInAdminView());
@@ -1409,7 +1404,7 @@ public class ApiKeyPage extends BasePage {
 				"Policy Group Description", "Policy Name Description", "Expiration Date" };
 
 		List<String> renderedLabels = new ArrayList<>();
-		for (WebElement label : driver.findElements(INDIVIDUAL_VIEW_LABELS)) {
+		for (WebElement label : individualViewFieldLabels) {
 			String text = label.getText().trim();
 			if (!text.isEmpty()) {
 				renderedLabels.add(text);
@@ -1445,7 +1440,7 @@ public class ApiKeyPage extends BasePage {
 		scrollIntoView(row);
 		row.click();
 
-		boolean detailsOpened = isElementDisplayedQuick(API_KEY_DETAILS_TITLE, Duration.ofSeconds(5));
+		boolean detailsOpened = isElementDisplayedQuick(By.xpath("//h1[text()='View API Key Details']"), Duration.ofSeconds(5));
 		if (detailsOpened) {
 			LogUtil.error("Deactivated API Key row opened the individual view");
 			takeScreenshot();
@@ -1459,8 +1454,8 @@ public class ApiKeyPage extends BasePage {
 
 	public boolean isExpirationDateStyledLikeOtherFields() {
 		By referenceLabel = By.id("api_key_details_partner_id_label");
-		By expirationLabel = isElementDisplayedQuick(EXPIRATION_DATE_LABEL, Duration.ofSeconds(5))
-				? EXPIRATION_DATE_LABEL
+		By expirationLabel = isElementDisplayedQuick(By.id("api_key_details_expiration_date_label"), Duration.ofSeconds(5))
+				? By.id("api_key_details_expiration_date_label")
 				: expirationDateLabelInAdminView();
 
 		try {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
@@ -427,8 +427,6 @@ public class ApiKeyPage extends BasePage {
 	@FindBy(id = "api_key_list_item1")
 	private WebElement activatedAdminApiKey;
 
-	// --- Expiration Date (TC_40334) ---
-
 	@FindBy(id = "apiKeyExpiryDateTime_desc_icon")
 	private WebElement apiKeyExpiryDateTime_desc_icon;
 
@@ -439,11 +437,6 @@ public class ApiKeyPage extends BasePage {
 		super(driver);
 	}
 
-	/**
-	 * The list renders each column header as
-	 * {@code <div id="{i18nKey}_header">}, which stays stable whatever the
-	 * display language, unlike the visible header text.
-	 */
 	private static final String CREATION_DATE_HEADER_ID = "oidcClientsList.creationDate_header";
 	private static final String EXPIRATION_DATE_HEADER_ID = "apiKeysList.expirationDate_header";
 
@@ -452,11 +445,6 @@ public class ApiKeyPage extends BasePage {
 	private static final By EXPIRATION_DATE_CONTEXT = By.id("api_key_details_expiration_date_context");
 	private static final By API_KEY_DETAILS_TITLE = By.xpath("//h1[text()='View API Key Details']");
 
-	/**
-	 * Expiration date is the column right after Creation Date, so the admin list
-	 * puts it at td[7] and the partner list, which has no Organisation column, at
-	 * td[6].
-	 */
 	private static final By ADMIN_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[7]");
 	private static final By PARTNER_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_list_item')][1]/td[6]");
 	private static final By ADMIN_CREATED_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[6]");
@@ -467,11 +455,9 @@ public class ApiKeyPage extends BasePage {
 	private static final By ADMIN_FIRST_ROW = By.id("api_key_list_item1");
 	private static final By PARTNER_FIRST_ROW = By.id("api_list_item1");
 
-	/** Field labels of the individual API Key view, in render order. */
 	private static final By INDIVIDUAL_VIEW_LABELS = By
 			.xpath("//p[starts-with(@id,'api_key_details_') and contains(@id,'_label')]");
 
-	/** Placeholder the list shows when a key carries no expiry date. */
 	private static final String NO_EXPIRY_TEXT = "No Expiry";
 
 	private static final Logger logger = Logger.getLogger(ApiKeyPage.class);
@@ -1255,16 +1241,10 @@ public class ApiKeyPage extends BasePage {
 		}
 	}
 
-	// ---------------------------------------------------------------
-	// Expiration Date in tabular view and individual view (TC_40334)
-	// ---------------------------------------------------------------
-
-	/** TC_40334_02 / _07: 'Expiration Date' column is rendered in the tabular view. */
 	public boolean isExpirationDateHeaderDisplayed() {
 		return isDisplayed(EXPIRATION_DATE_HEADER);
 	}
 
-	/** TC_40334_02: 'Expiration Date' sits immediately after 'Creation Date'. */
 	public boolean isExpirationDateHeaderAfterCreationDate() {
 		int creationIndex = getColumnIndex(CREATION_DATE_HEADER_ID);
 		int expirationIndex = getColumnIndex(EXPIRATION_DATE_HEADER_ID);
@@ -1300,10 +1280,6 @@ public class ApiKeyPage extends BasePage {
 		clickOnElement(apiKeyExpiryDateTime_asc_icon);
 	}
 
-	/**
-	 * TC_40334_03: reads the Expiration Date column and asserts the requested
-	 * ordering. Rows showing 'No Expiry' are ignored — they carry no date to sort.
-	 */
 	public boolean isExpiryDateColumnSorted(boolean ascending, boolean isAdminView) {
 		List<LocalDate> dates = readExpiryColumn(isAdminView);
 		if (dates.size() < 2) {
@@ -1342,10 +1318,6 @@ public class ApiKeyPage extends BasePage {
 		return dates;
 	}
 
-	/**
-	 * TC_40334_05 / _08: the expiration date renders in the browser locale format
-	 * that {@code formatDate(..,'date')} produces, i.e. M/d/yyyy for en-US.
-	 */
 	public boolean isExpirationDateSameAsBrowserDateFormat(boolean isAdminView) {
 		By cellLocator = isAdminView ? ADMIN_EXPIRY_CELL : PARTNER_EXPIRY_CELL;
 		try {
@@ -1373,11 +1345,6 @@ public class ApiKeyPage extends BasePage {
 		}
 	}
 
-	/**
-	 * TC_40334_08: expiration date equals creation date plus the configured
-	 * duration. {@code expectedDays <= 0} means the backend property is unset, in
-	 * which case PMS applies its 100 year default.
-	 */
 	public boolean isExpirationDateOffsetFromCreationDate(int expectedDays, boolean isAdminView) {
 		By createdLocator = isAdminView ? ADMIN_CREATED_CELL : PARTNER_CREATED_CELL;
 		By expiryLocator = isAdminView ? ADMIN_EXPIRY_CELL : PARTNER_EXPIRY_CELL;
@@ -1415,13 +1382,6 @@ public class ApiKeyPage extends BasePage {
 		}
 	}
 
-	/**
-	 * TC_40334_04 / _13: Expiration Date is present in the individual view.
-	 *
-	 * The partner view gives the field its own ids. The admin view reuses the
-	 * policy-name-description ids for it, so there the field is reached through its
-	 * label text instead.
-	 */
 	public boolean isApiKeyDetailsExpirationDateLabelDisplayed() {
 		if (isElementDisplayedQuick(EXPIRATION_DATE_LABEL, Duration.ofSeconds(5))) {
 			return true;
@@ -1444,12 +1404,6 @@ public class ApiKeyPage extends BasePage {
 		return By.xpath("//p[normalize-space()='Expiration Date']/following-sibling::p[1]");
 	}
 
-	/**
-	 * TC_40334_06: the individual view renders its fields in the order Partner ID,
-	 * Partner Type, Policy Group, Policy Name, Policy Group Description, Policy Name
-	 * Description, Expiration Date. Extra fields the admin view adds (Organisation)
-	 * are tolerated; only the relative order of the expected fields is asserted.
-	 */
 	public boolean isIndividualViewFieldOrderCorrect() {
 		String[] expectedOrder = { "Partner ID", "Partner Type", "Policy Group", "Policy Name",
 				"Policy Group Description", "Policy Name Description", "Expiration Date" };
@@ -1482,21 +1436,12 @@ public class ApiKeyPage extends BasePage {
 		return true;
 	}
 
-	/**
-	 * TC_40334_14: a Deactivated row must not open the individual view. Clicks the
-	 * row and reports whether the details page stayed closed.
-	 *
-	 * Throws when the row is not on the page at all, so a filter that returned
-	 * nothing is reported as an error rather than as a passing check.
-	 */
 	public boolean isDeactivatedRowNotClickable(boolean isAdminView) {
 		By rowLocator = isAdminView ? ADMIN_FIRST_ROW : PARTNER_FIRST_ROW;
 
 		WebElement row = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
 				.until(ExpectedConditions.visibilityOfElementLocated(rowLocator));
 
-		// A plain click, not clickOnElement(): its JavaScript fallback would bypass the
-		// very guard under test and report a deactivated row as clickable.
 		scrollIntoView(row);
 		row.click();
 
@@ -1508,19 +1453,10 @@ public class ApiKeyPage extends BasePage {
 		return !detailsOpened;
 	}
 
-	/** TC_40334_09: after submitting, the API Key list view is shown again. */
 	public boolean isApiKeyListViewDisplayed() {
 		return isElementDisplayed(subTitleOfTabularView);
 	}
 
-	/**
-	 * TC_40334_10: the Expiration Date field carries the same typography as the
-	 * other fields of the individual view, so it reads as part of the same design
-	 * rather than as a bolt-on.
-	 *
-	 * Compares the computed font of the Expiration Date label against the Partner
-	 * ID label, which is the established pattern for a field label on this page.
-	 */
 	public boolean isExpirationDateStyledLikeOtherFields() {
 		By referenceLabel = By.id("api_key_details_partner_id_label");
 		By expirationLabel = isElementDisplayedQuick(EXPIRATION_DATE_LABEL, Duration.ofSeconds(5))

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
@@ -454,6 +454,9 @@ public class ApiKeyPage extends BasePage {
 	@FindBy(id = "api_key_details_expiration_date_label")
 	private WebElement apiKeyDetailsExpirationDateLabel;
 
+	@FindBy(id = "api_key_details_expiration_date_context")
+	private WebElement apiKeyDetailsExpirationDateContext;
+
 	@FindBy(xpath = "//p[normalize-space()='Expiration Date']")
 	private WebElement expirationDateLabelInAdminView;
 
@@ -1356,14 +1359,14 @@ public class ApiKeyPage extends BasePage {
 		}
 	}
 
-	public boolean isExpirationDateOffsetFromCreationDate(int expectedDays, boolean isAdminView) {
+	public boolean isExpirationDateNotBeforeCreationDate(boolean isAdminView) {
 		WebElement creationDateCell = isAdminView ? adminCreationDateCell : partnerCreationDateCell;
 		WebElement expirationDateCell = isAdminView ? adminExpirationDateCell : partnerExpirationDateCell;
 		try {
 			WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()));
 			String created = wait.until(ExpectedConditions.visibilityOf(creationDateCell)).getText().trim();
 			String expiry = wait.until(ExpectedConditions.visibilityOf(expirationDateCell)).getText().trim();
-			LogUtil.step("Created: " + created + ", Expiry: " + expiry + ", expected offset(days): " + expectedDays);
+			LogUtil.step("Created: " + created + ", Expiry: " + expiry);
 
 			if (expiry.equalsIgnoreCase(NO_EXPIRY_TEXT)) {
 				LogUtil.error("Expiration date not set for the API key");
@@ -1372,11 +1375,9 @@ public class ApiKeyPage extends BasePage {
 			}
 			LocalDate createdDate = LocalDate.parse(created, PmpTestUtil.nonZeroPadderDateFormatter);
 			LocalDate expiryDate = LocalDate.parse(expiry, PmpTestUtil.nonZeroPadderDateFormatter);
-			LocalDate expected = expectedDays > 0 ? createdDate.plusDays(expectedDays) : createdDate.plusYears(100);
-			LogUtil.step("Expected expiration date: " + expected);
 
-			if (!expected.equals(expiryDate)) {
-				LogUtil.error("Expiration date " + expiryDate + " does not match the expected " + expected);
+			if (expiryDate.isBefore(createdDate)) {
+				LogUtil.error("Expiration date " + expiryDate + " is earlier than the creation date " + createdDate);
 				takeScreenshot();
 				return false;
 			}
@@ -1398,6 +1399,19 @@ public class ApiKeyPage extends BasePage {
 			return true;
 		}
 		return isElementDisplayed(expirationDateLabelInAdminView);
+	}
+
+	public String getExpirationDateFromList(boolean isAdminView) {
+		WebElement expirationDateCell = isAdminView ? adminExpirationDateCell : partnerExpirationDateCell;
+		return new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
+				.until(ExpectedConditions.visibilityOf(expirationDateCell)).getText().trim();
+	}
+
+	public String getExpirationDateFromIndividualView() {
+		if (isElementDisplayedQuick(By.id("api_key_details_expiration_date_context"), Duration.ofSeconds(5))) {
+			return getTextFromLocator(apiKeyDetailsExpirationDateContext).trim();
+		}
+		return getTextFromLocator(expirationDateContextInAdminView).trim();
 	}
 
 	public boolean isApiKeyDetailsExpirationDateContextDisplayed() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
@@ -4,6 +4,9 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.TimeoutException;
 import org.apache.log4j.Logger;
 import org.openqa.selenium.By;
@@ -424,9 +427,52 @@ public class ApiKeyPage extends BasePage {
 	@FindBy(id = "api_key_list_item1")
 	private WebElement activatedAdminApiKey;
 
+	// --- Expiration Date (TC_40334) ---
+
+	@FindBy(id = "apiKeyExpiryDateTime_desc_icon")
+	private WebElement apiKeyExpiryDateTime_desc_icon;
+
+	@FindBy(id = "apiKeyExpiryDateTime_asc_icon")
+	private WebElement apiKeyExpiryDateTime_asc_icon;
+
 	public ApiKeyPage(WebDriver driver) {
 		super(driver);
 	}
+
+	/**
+	 * The list renders each column header as
+	 * {@code <div id="{i18nKey}_header">}, which stays stable whatever the
+	 * display language, unlike the visible header text.
+	 */
+	private static final String CREATION_DATE_HEADER_ID = "oidcClientsList.creationDate_header";
+	private static final String EXPIRATION_DATE_HEADER_ID = "apiKeysList.expirationDate_header";
+
+	private static final By EXPIRATION_DATE_HEADER = By.xpath("//*[@id='" + EXPIRATION_DATE_HEADER_ID + "']");
+	private static final By EXPIRATION_DATE_LABEL = By.id("api_key_details_expiration_date_label");
+	private static final By EXPIRATION_DATE_CONTEXT = By.id("api_key_details_expiration_date_context");
+	private static final By API_KEY_DETAILS_TITLE = By.xpath("//h1[text()='View API Key Details']");
+
+	/**
+	 * Expiration date is the column right after Creation Date, so the admin list
+	 * puts it at td[7] and the partner list, which has no Organisation column, at
+	 * td[6].
+	 */
+	private static final By ADMIN_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[7]");
+	private static final By PARTNER_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_list_item')][1]/td[6]");
+	private static final By ADMIN_CREATED_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[6]");
+	private static final By PARTNER_CREATED_CELL = By.xpath("//tr[starts-with(@id,'api_list_item')][1]/td[5]");
+	private static final By ADMIN_EXPIRY_COLUMN = By.xpath("//tr[starts-with(@id,'api_key_list_item')]/td[7]");
+	private static final By PARTNER_EXPIRY_COLUMN = By.xpath("//tr[starts-with(@id,'api_list_item')]/td[6]");
+
+	private static final By ADMIN_FIRST_ROW = By.id("api_key_list_item1");
+	private static final By PARTNER_FIRST_ROW = By.id("api_list_item1");
+
+	/** Field labels of the individual API Key view, in render order. */
+	private static final By INDIVIDUAL_VIEW_LABELS = By
+			.xpath("//p[starts-with(@id,'api_key_details_') and contains(@id,'_label')]");
+
+	/** Placeholder the list shows when a key carries no expiry date. */
+	private static final String NO_EXPIRY_TEXT = "No Expiry";
 
 	private static final Logger logger = Logger.getLogger(ApiKeyPage.class);
 
@@ -1204,6 +1250,303 @@ public class ApiKeyPage extends BasePage {
 
 		} catch (DateTimeParseException e) {
 			LogUtil.error("Date format mismatch: " + e.getMessage());
+			takeScreenshot();
+			return false;
+		}
+	}
+
+	// ---------------------------------------------------------------
+	// Expiration Date in tabular view and individual view (TC_40334)
+	// ---------------------------------------------------------------
+
+	/** TC_40334_02 / _07: 'Expiration Date' column is rendered in the tabular view. */
+	public boolean isExpirationDateHeaderDisplayed() {
+		return isDisplayed(EXPIRATION_DATE_HEADER);
+	}
+
+	/** TC_40334_02: 'Expiration Date' sits immediately after 'Creation Date'. */
+	public boolean isExpirationDateHeaderAfterCreationDate() {
+		int creationIndex = getColumnIndex(CREATION_DATE_HEADER_ID);
+		int expirationIndex = getColumnIndex(EXPIRATION_DATE_HEADER_ID);
+		LogUtil.step("Creation Date column index: " + creationIndex + ", Expiration Date column index: "
+				+ expirationIndex);
+
+		if (creationIndex < 0 || expirationIndex < 0) {
+			LogUtil.error("Creation Date or Expiration Date column header is missing from the table");
+			takeScreenshot();
+			return false;
+		}
+		if (expirationIndex != creationIndex + 1) {
+			LogUtil.error("Expiration Date is not the column immediately after Creation Date");
+			takeScreenshot();
+			return false;
+		}
+		return true;
+	}
+
+	public boolean isExpiryDateDescIconDisplayed() {
+		return isElementDisplayed(apiKeyExpiryDateTime_desc_icon);
+	}
+
+	public boolean isExpiryDateAscIconDisplayed() {
+		return isElementDisplayed(apiKeyExpiryDateTime_asc_icon);
+	}
+
+	public void clickOnExpiryDateDescIcon() {
+		clickOnElement(apiKeyExpiryDateTime_desc_icon);
+	}
+
+	public void clickOnExpiryDateAscIcon() {
+		clickOnElement(apiKeyExpiryDateTime_asc_icon);
+	}
+
+	/**
+	 * TC_40334_03: reads the Expiration Date column and asserts the requested
+	 * ordering. Rows showing 'No Expiry' are ignored — they carry no date to sort.
+	 */
+	public boolean isExpiryDateColumnSorted(boolean ascending, boolean isAdminView) {
+		List<LocalDate> dates = readExpiryColumn(isAdminView);
+		if (dates.size() < 2) {
+			LogUtil.error("Only " + dates.size() + " dated row(s) on the page, which cannot demonstrate sorting");
+			takeScreenshot();
+			return false;
+		}
+		for (int i = 1; i < dates.size(); i++) {
+			boolean inOrder = ascending ? !dates.get(i).isBefore(dates.get(i - 1))
+					: !dates.get(i).isAfter(dates.get(i - 1));
+			if (!inOrder) {
+				LogUtil.error("Expiration Date not sorted " + (ascending ? "ascending" : "descending") + " at row "
+						+ (i + 1) + ": " + dates.get(i - 1) + " then " + dates.get(i));
+				takeScreenshot();
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private List<LocalDate> readExpiryColumn(boolean isAdminView) {
+		By columnLocator = isAdminView ? ADMIN_EXPIRY_COLUMN : PARTNER_EXPIRY_COLUMN;
+		List<LocalDate> dates = new ArrayList<>();
+		for (WebElement cell : driver.findElements(columnLocator)) {
+			String value = cell.getText().trim();
+			if (value.isEmpty() || value.equalsIgnoreCase(NO_EXPIRY_TEXT) || value.equals("-")) {
+				continue;
+			}
+			try {
+				dates.add(LocalDate.parse(value, PmpTestUtil.nonZeroPadderDateFormatter));
+			} catch (DateTimeParseException e) {
+				LogUtil.step("Skipping unparsable expiry value: " + value);
+			}
+		}
+		LogUtil.step("Expiration dates read from column: " + dates);
+		return dates;
+	}
+
+	/**
+	 * TC_40334_05 / _08: the expiration date renders in the browser locale format
+	 * that {@code formatDate(..,'date')} produces, i.e. M/d/yyyy for en-US.
+	 */
+	public boolean isExpirationDateSameAsBrowserDateFormat(boolean isAdminView) {
+		By cellLocator = isAdminView ? ADMIN_EXPIRY_CELL : PARTNER_EXPIRY_CELL;
+		try {
+			WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()));
+			WebElement cell = wait.until(ExpectedConditions.visibilityOfElementLocated(cellLocator));
+			String value = cell.getText().trim();
+			LogUtil.step("API key expiration date from UI: " + value);
+
+			if (value.equalsIgnoreCase(NO_EXPIRY_TEXT)) {
+				LogUtil.error("First row carries no expiry date, so the locale format cannot be verified");
+				takeScreenshot();
+				return false;
+			}
+			LocalDate.parse(value, PmpTestUtil.nonZeroPadderDateFormatter);
+			return true;
+
+		} catch (TimeoutException e) {
+			LogUtil.error("API key expiration cell not visible in time");
+			takeScreenshot();
+			return false;
+		} catch (DateTimeParseException e) {
+			LogUtil.error("Expiration date format mismatch: " + e.getMessage());
+			takeScreenshot();
+			return false;
+		}
+	}
+
+	/**
+	 * TC_40334_08: expiration date equals creation date plus the configured
+	 * duration. {@code expectedDays <= 0} means the backend property is unset, in
+	 * which case PMS applies its 100 year default.
+	 */
+	public boolean isExpirationDateOffsetFromCreationDate(int expectedDays, boolean isAdminView) {
+		By createdLocator = isAdminView ? ADMIN_CREATED_CELL : PARTNER_CREATED_CELL;
+		By expiryLocator = isAdminView ? ADMIN_EXPIRY_CELL : PARTNER_EXPIRY_CELL;
+		try {
+			WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()));
+			String created = wait.until(ExpectedConditions.visibilityOfElementLocated(createdLocator)).getText().trim();
+			String expiry = wait.until(ExpectedConditions.visibilityOfElementLocated(expiryLocator)).getText().trim();
+			LogUtil.step("Created: " + created + ", Expiry: " + expiry + ", expected offset(days): " + expectedDays);
+
+			if (expiry.equalsIgnoreCase(NO_EXPIRY_TEXT)) {
+				LogUtil.error("Expiration date not set for the API key");
+				takeScreenshot();
+				return false;
+			}
+			LocalDate createdDate = LocalDate.parse(created, PmpTestUtil.nonZeroPadderDateFormatter);
+			LocalDate expiryDate = LocalDate.parse(expiry, PmpTestUtil.nonZeroPadderDateFormatter);
+			LocalDate expected = expectedDays > 0 ? createdDate.plusDays(expectedDays) : createdDate.plusYears(100);
+			LogUtil.step("Expected expiration date: " + expected);
+
+			if (!expected.equals(expiryDate)) {
+				LogUtil.error("Expiration date " + expiryDate + " does not match the expected " + expected);
+				takeScreenshot();
+				return false;
+			}
+			return true;
+
+		} catch (TimeoutException e) {
+			LogUtil.error("Creation or expiration cell not visible in time");
+			takeScreenshot();
+			return false;
+		} catch (DateTimeParseException e) {
+			LogUtil.error("Could not parse the creation or expiration date: " + e.getMessage());
+			takeScreenshot();
+			return false;
+		}
+	}
+
+	/**
+	 * TC_40334_04 / _13: Expiration Date is present in the individual view.
+	 *
+	 * The partner view gives the field its own ids. The admin view reuses the
+	 * policy-name-description ids for it, so there the field is reached through its
+	 * label text instead.
+	 */
+	public boolean isApiKeyDetailsExpirationDateLabelDisplayed() {
+		if (isElementDisplayedQuick(EXPIRATION_DATE_LABEL, Duration.ofSeconds(5))) {
+			return true;
+		}
+		return isDisplayed(expirationDateLabelInAdminView());
+	}
+
+	public boolean isApiKeyDetailsExpirationDateContextDisplayed() {
+		if (isElementDisplayedQuick(EXPIRATION_DATE_CONTEXT, Duration.ofSeconds(5))) {
+			return true;
+		}
+		return isDisplayed(expirationDateContextInAdminView());
+	}
+
+	private By expirationDateLabelInAdminView() {
+		return By.xpath("//p[normalize-space()='Expiration Date']");
+	}
+
+	private By expirationDateContextInAdminView() {
+		return By.xpath("//p[normalize-space()='Expiration Date']/following-sibling::p[1]");
+	}
+
+	/**
+	 * TC_40334_06: the individual view renders its fields in the order Partner ID,
+	 * Partner Type, Policy Group, Policy Name, Policy Group Description, Policy Name
+	 * Description, Expiration Date. Extra fields the admin view adds (Organisation)
+	 * are tolerated; only the relative order of the expected fields is asserted.
+	 */
+	public boolean isIndividualViewFieldOrderCorrect() {
+		String[] expectedOrder = { "Partner ID", "Partner Type", "Policy Group", "Policy Name",
+				"Policy Group Description", "Policy Name Description", "Expiration Date" };
+
+		List<String> renderedLabels = new ArrayList<>();
+		for (WebElement label : driver.findElements(INDIVIDUAL_VIEW_LABELS)) {
+			String text = label.getText().trim();
+			if (!text.isEmpty()) {
+				renderedLabels.add(text);
+			}
+		}
+		LogUtil.step("Individual view labels in render order: " + renderedLabels);
+
+		int cursor = -1;
+		for (String expected : expectedOrder) {
+			int found = renderedLabels.indexOf(expected);
+			if (found < 0) {
+				LogUtil.error("Field missing from individual view: " + expected);
+				takeScreenshot();
+				return false;
+			}
+			if (found <= cursor) {
+				LogUtil.error("Field out of sequence: " + expected + " at index " + found + ", expected after "
+						+ cursor);
+				takeScreenshot();
+				return false;
+			}
+			cursor = found;
+		}
+		return true;
+	}
+
+	/**
+	 * TC_40334_14: a Deactivated row must not open the individual view. Clicks the
+	 * row and reports whether the details page stayed closed.
+	 *
+	 * Throws when the row is not on the page at all, so a filter that returned
+	 * nothing is reported as an error rather than as a passing check.
+	 */
+	public boolean isDeactivatedRowNotClickable(boolean isAdminView) {
+		By rowLocator = isAdminView ? ADMIN_FIRST_ROW : PARTNER_FIRST_ROW;
+
+		WebElement row = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
+				.until(ExpectedConditions.visibilityOfElementLocated(rowLocator));
+
+		// A plain click, not clickOnElement(): its JavaScript fallback would bypass the
+		// very guard under test and report a deactivated row as clickable.
+		scrollIntoView(row);
+		row.click();
+
+		boolean detailsOpened = isElementDisplayedQuick(API_KEY_DETAILS_TITLE, Duration.ofSeconds(5));
+		if (detailsOpened) {
+			LogUtil.error("Deactivated API Key row opened the individual view");
+			takeScreenshot();
+		}
+		return !detailsOpened;
+	}
+
+	/** TC_40334_09: after submitting, the API Key list view is shown again. */
+	public boolean isApiKeyListViewDisplayed() {
+		return isElementDisplayed(subTitleOfTabularView);
+	}
+
+	/**
+	 * TC_40334_10: the Expiration Date field carries the same typography as the
+	 * other fields of the individual view, so it reads as part of the same design
+	 * rather than as a bolt-on.
+	 *
+	 * Compares the computed font of the Expiration Date label against the Partner
+	 * ID label, which is the established pattern for a field label on this page.
+	 */
+	public boolean isExpirationDateStyledLikeOtherFields() {
+		By referenceLabel = By.id("api_key_details_partner_id_label");
+		By expirationLabel = isElementDisplayedQuick(EXPIRATION_DATE_LABEL, Duration.ofSeconds(5))
+				? EXPIRATION_DATE_LABEL
+				: expirationDateLabelInAdminView();
+
+		try {
+			WebElement reference = driver.findElement(referenceLabel);
+			WebElement expiration = driver.findElement(expirationLabel);
+
+			for (String property : new String[] { "font-family", "font-size", "font-weight", "color" }) {
+				String expected = reference.getCssValue(property);
+				String actual = expiration.getCssValue(property);
+				LogUtil.step("Label " + property + " - Partner ID: " + expected + ", Expiration Date: " + actual);
+
+				if (!expected.equals(actual)) {
+					LogUtil.error("Expiration Date label " + property + " is " + actual + " but the other field "
+							+ "labels use " + expected);
+					takeScreenshot();
+					return false;
+				}
+			}
+			return true;
+
+		} catch (NoSuchElementException e) {
+			LogUtil.error("Could not find the Expiration Date label or the reference label to compare against");
 			takeScreenshot();
 			return false;
 		}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ApiKeyPage.java
@@ -433,6 +433,33 @@ public class ApiKeyPage extends BasePage {
 	@FindBy(xpath = "//p[starts-with(@id,'api_key_details_') and contains(@id,'_label')]")
 	private List<WebElement> individualViewFieldLabels;
 
+	@FindBy(xpath = "//tr[@id='api_key_list_item1']/td[7]")
+	private WebElement adminExpirationDateCell;
+
+	@FindBy(xpath = "//tr[@id='api_list_item1']/td[6]")
+	private WebElement partnerExpirationDateCell;
+
+	@FindBy(xpath = "//tr[@id='api_key_list_item1']/td[6]")
+	private WebElement adminCreationDateCell;
+
+	@FindBy(xpath = "//tr[@id='api_list_item1']/td[5]")
+	private WebElement partnerCreationDateCell;
+
+	@FindBy(xpath = "//tr[starts-with(@id,'api_key_list_item')]/td[7]")
+	private List<WebElement> adminExpirationDateColumn;
+
+	@FindBy(xpath = "//tr[starts-with(@id,'api_list_item')]/td[6]")
+	private List<WebElement> partnerExpirationDateColumn;
+
+	@FindBy(id = "api_key_details_expiration_date_label")
+	private WebElement apiKeyDetailsExpirationDateLabel;
+
+	@FindBy(xpath = "//p[normalize-space()='Expiration Date']")
+	private WebElement expirationDateLabelInAdminView;
+
+	@FindBy(xpath = "//p[normalize-space()='Expiration Date']/following-sibling::p[1]")
+	private WebElement expirationDateContextInAdminView;
+
 	@FindBy(id = "apiKeyExpiryDateTime_desc_icon")
 	private WebElement apiKeyExpiryDateTime_desc_icon;
 
@@ -442,16 +469,6 @@ public class ApiKeyPage extends BasePage {
 	public ApiKeyPage(WebDriver driver) {
 		super(driver);
 	}
-
-	private static final By ADMIN_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[7]");
-	private static final By PARTNER_EXPIRY_CELL = By.xpath("//tr[starts-with(@id,'api_list_item')][1]/td[6]");
-	private static final By ADMIN_CREATED_CELL = By.xpath("//tr[starts-with(@id,'api_key_list_item')][1]/td[6]");
-	private static final By PARTNER_CREATED_CELL = By.xpath("//tr[starts-with(@id,'api_list_item')][1]/td[5]");
-	private static final By ADMIN_EXPIRY_COLUMN = By.xpath("//tr[starts-with(@id,'api_key_list_item')]/td[7]");
-	private static final By PARTNER_EXPIRY_COLUMN = By.xpath("//tr[starts-with(@id,'api_list_item')]/td[6]");
-
-	private static final By ADMIN_FIRST_ROW = By.id("api_key_list_item1");
-	private static final By PARTNER_FIRST_ROW = By.id("api_list_item1");
 
 	private static final String NO_EXPIRY_TEXT = "No Expiry";
 
@@ -1296,9 +1313,9 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	private List<LocalDate> readExpiryColumn(boolean isAdminView) {
-		By columnLocator = isAdminView ? ADMIN_EXPIRY_COLUMN : PARTNER_EXPIRY_COLUMN;
+		List<WebElement> expirationDateColumn = isAdminView ? adminExpirationDateColumn : partnerExpirationDateColumn;
 		List<LocalDate> dates = new ArrayList<>();
-		for (WebElement cell : driver.findElements(columnLocator)) {
+		for (WebElement cell : expirationDateColumn) {
 			String value = cell.getText().trim();
 			if (value.isEmpty() || value.equalsIgnoreCase(NO_EXPIRY_TEXT) || value.equals("-")) {
 				continue;
@@ -1314,11 +1331,10 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	public boolean isExpirationDateSameAsBrowserDateFormat(boolean isAdminView) {
-		By cellLocator = isAdminView ? ADMIN_EXPIRY_CELL : PARTNER_EXPIRY_CELL;
+		WebElement expirationDateCell = isAdminView ? adminExpirationDateCell : partnerExpirationDateCell;
 		try {
 			WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()));
-			WebElement cell = wait.until(ExpectedConditions.visibilityOfElementLocated(cellLocator));
-			String value = cell.getText().trim();
+			String value = wait.until(ExpectedConditions.visibilityOf(expirationDateCell)).getText().trim();
 			LogUtil.step("API key expiration date from UI: " + value);
 
 			if (value.equalsIgnoreCase(NO_EXPIRY_TEXT)) {
@@ -1341,12 +1357,12 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	public boolean isExpirationDateOffsetFromCreationDate(int expectedDays, boolean isAdminView) {
-		By createdLocator = isAdminView ? ADMIN_CREATED_CELL : PARTNER_CREATED_CELL;
-		By expiryLocator = isAdminView ? ADMIN_EXPIRY_CELL : PARTNER_EXPIRY_CELL;
+		WebElement creationDateCell = isAdminView ? adminCreationDateCell : partnerCreationDateCell;
+		WebElement expirationDateCell = isAdminView ? adminExpirationDateCell : partnerExpirationDateCell;
 		try {
 			WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()));
-			String created = wait.until(ExpectedConditions.visibilityOfElementLocated(createdLocator)).getText().trim();
-			String expiry = wait.until(ExpectedConditions.visibilityOfElementLocated(expiryLocator)).getText().trim();
+			String created = wait.until(ExpectedConditions.visibilityOf(creationDateCell)).getText().trim();
+			String expiry = wait.until(ExpectedConditions.visibilityOf(expirationDateCell)).getText().trim();
 			LogUtil.step("Created: " + created + ", Expiry: " + expiry + ", expected offset(days): " + expectedDays);
 
 			if (expiry.equalsIgnoreCase(NO_EXPIRY_TEXT)) {
@@ -1381,22 +1397,14 @@ public class ApiKeyPage extends BasePage {
 		if (isElementDisplayedQuick(By.id("api_key_details_expiration_date_label"), Duration.ofSeconds(5))) {
 			return true;
 		}
-		return isDisplayed(expirationDateLabelInAdminView());
+		return isElementDisplayed(expirationDateLabelInAdminView);
 	}
 
 	public boolean isApiKeyDetailsExpirationDateContextDisplayed() {
 		if (isElementDisplayedQuick(By.id("api_key_details_expiration_date_context"), Duration.ofSeconds(5))) {
 			return true;
 		}
-		return isDisplayed(expirationDateContextInAdminView());
-	}
-
-	private By expirationDateLabelInAdminView() {
-		return By.xpath("//p[normalize-space()='Expiration Date']");
-	}
-
-	private By expirationDateContextInAdminView() {
-		return By.xpath("//p[normalize-space()='Expiration Date']/following-sibling::p[1]");
+		return isElementDisplayed(expirationDateContextInAdminView);
 	}
 
 	public boolean isIndividualViewFieldOrderCorrect() {
@@ -1432,10 +1440,10 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	public boolean isDeactivatedRowNotClickable(boolean isAdminView) {
-		By rowLocator = isAdminView ? ADMIN_FIRST_ROW : PARTNER_FIRST_ROW;
+		WebElement row = isAdminView ? apiKeyItem1 : apiListItem1;
 
-		WebElement row = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
-				.until(ExpectedConditions.visibilityOfElementLocated(rowLocator));
+		new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
+				.until(ExpectedConditions.visibilityOf(row));
 
 		scrollIntoView(row);
 		row.click();
@@ -1453,17 +1461,12 @@ public class ApiKeyPage extends BasePage {
 	}
 
 	public boolean isExpirationDateStyledLikeOtherFields() {
-		By referenceLabel = By.id("api_key_details_partner_id_label");
-		By expirationLabel = isElementDisplayedQuick(By.id("api_key_details_expiration_date_label"), Duration.ofSeconds(5))
-				? By.id("api_key_details_expiration_date_label")
-				: expirationDateLabelInAdminView();
+		WebElement expiration = isElementDisplayedQuick(By.id("api_key_details_expiration_date_label"),
+				Duration.ofSeconds(5)) ? apiKeyDetailsExpirationDateLabel : expirationDateLabelInAdminView;
 
 		try {
-			WebElement reference = driver.findElement(referenceLabel);
-			WebElement expiration = driver.findElement(expirationLabel);
-
 			for (String property : new String[] { "font-family", "font-size", "font-weight", "color" }) {
-				String expected = reference.getCssValue(property);
+				String expected = apiKeyDetailsPartnerIdLabel.getCssValue(property);
 				String actual = expiration.getCssValue(property);
 				LogUtil.step("Label " + property + " - Partner ID: " + expected + ", Expiration Date: " + actual);
 

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -738,14 +738,6 @@ public class BasePage {
 		return wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
 	}
 
-	/**
-	 * Zero-based position of the list column whose header carries the given id, or
-	 * -1 when no header cell holds it.
-	 *
-	 * Every list in the portal renders its column headers as
-	 * {@code <div id="{i18nKey}_header">}, which stays stable whatever the display
-	 * language, unlike the visible header text.
-	 */
 	protected int getColumnIndex(String headerId) {
 		java.util.List<WebElement> headerCells = driver.findElements(By.xpath("//thead//th"));
 		for (int i = 0; i < headerCells.size(); i++) {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -738,4 +738,23 @@ public class BasePage {
 		return wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
 	}
 
+	/**
+	 * Zero-based position of the list column whose header carries the given id, or
+	 * -1 when no header cell holds it.
+	 *
+	 * Every list in the portal renders its column headers as
+	 * {@code <div id="{i18nKey}_header">}, which stays stable whatever the display
+	 * language, unlike the visible header text.
+	 */
+	protected int getColumnIndex(String headerId) {
+		java.util.List<WebElement> headerCells = driver.findElements(By.xpath("//thead//th"));
+		for (int i = 0; i < headerCells.size(); i++) {
+			if (!headerCells.get(i).findElements(By.xpath(".//*[@id='" + headerId + "']")).isEmpty()) {
+				return i;
+			}
+		}
+		LogUtil.step("No column header found with id: " + headerId);
+		return -1;
+	}
+
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -741,7 +741,7 @@ public class BasePage {
 	protected int getColumnIndex(String headerId) {
 		java.util.List<WebElement> headerCells = driver.findElements(By.xpath("//thead//th"));
 		for (int i = 0; i < headerCells.size(); i++) {
-			if (!headerCells.get(i).findElements(By.xpath(".//*[@id='" + headerId + "']")).isEmpty()) {
+			if (!headerCells.get(i).findElements(By.id(headerId)).isEmpty()) {
 				return i;
 			}
 		}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/IndividualViewPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/IndividualViewPage.java
@@ -13,13 +13,6 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import io.mosip.testrig.pmpuiv2.kernel.util.ConfigManager;
 import io.mosip.testrig.pmpuiv2.utility.LogUtil;
 
-/**
- * Approve/Reject controls rendered on the Partner Admin individual view pages.
- *
- * The button and the confirmation popup are the same components on every
- * individual view that supports admin approval - Policies, FTM Chip,
- * Authentication Services and SBI-Device - so one page object serves them all.
- */
 public class IndividualViewPage extends BasePage {
 
 	private static final String APPROVE_REJECT_BUTTON_ID = "view_approve_reject_btn";
@@ -30,17 +23,10 @@ public class IndividualViewPage extends BasePage {
 	private static final By APPROVE_REJECT_BUTTON = By.id(APPROVE_REJECT_BUTTON_ID);
 	private static final By APPROVE_REJECT_POPUP_TITLE = By.id(APPROVE_REJECT_POPUP_TITLE_ID);
 
-	/** Upper bound on the tab walk, so a layout change cannot spin the test. */
 	private static final int MAX_TAB_PRESSES = 30;
 
-	/** Colour coding applied by bgOfStatus() in the portal's AppUtils. */
 	private static final String ACTIVATED_STATUS_CLASS = "bg-[#D1FADF]";
 	private static final String DEACTIVATED_STATUS_CLASS = "bg-[#EAECF0]";
-
-	/**
-	 * getStatusCode() renders an activated partner as 'Active', so that is the text
-	 * to expect on screen even though the story calls the state 'Activated'.
-	 */
 	private static final String ACTIVATED_STATUS_TEXT = "Active";
 	private static final String DEACTIVATED_STATUS_TEXT = "Deactivated";
 
@@ -75,18 +61,10 @@ public class IndividualViewPage extends BasePage {
 		super(driver);
 	}
 
-	// --- Approve/Reject button (TC_38408_01, _02, _10, _14) ---
-
-	/** TC_38408_01: the button is rendered for a Pending for Approval record. */
 	public boolean isApproveRejectButtonDisplayed() {
 		return isElementDisplayed(individualViewApproveRejectButton);
 	}
 
-	/**
-	 * TC_38408_02 and TC_38408_14: the button is absent for records that cannot be
-	 * actioned. Probes briefly rather than waiting out the full timeout, since the
-	 * expected outcome is that nothing is there.
-	 */
 	public boolean isApproveRejectButtonAbsent() {
 		boolean present = isElementDisplayedQuick(APPROVE_REJECT_BUTTON, Duration.ofSeconds(5));
 		if (present) {
@@ -96,7 +74,6 @@ public class IndividualViewPage extends BasePage {
 		return !present;
 	}
 
-	/** TC_38408_10: the button stays enabled for a deactivated partner. */
 	public boolean isApproveRejectButtonEnabled() {
 		return isElementEnabled(individualViewApproveRejectButton);
 	}
@@ -104,8 +81,6 @@ public class IndividualViewPage extends BasePage {
 	public void clickOnApproveRejectButton() {
 		clickOnElement(individualViewApproveRejectButton);
 	}
-
-	// --- Confirmation popup (TC_38408_03) ---
 
 	public boolean isApproveRejectPopupDisplayed() {
 		return isElementDisplayed(approveRejectPopupTitle);
@@ -139,9 +114,6 @@ public class IndividualViewPage extends BasePage {
 		clickOnElement(approveRejectPopupCloseIcon);
 	}
 
-	// --- Partner Status field (TC_38408_04, _05, _06) ---
-
-	/** TC_38408_04: the field is present regardless of the record status. */
 	public boolean isPartnerStatusLabelDisplayed() {
 		return isElementDisplayed(partnerStatusLabel);
 	}
@@ -150,12 +122,10 @@ public class IndividualViewPage extends BasePage {
 		return getTextFromLocator(partnerStatusContext).trim();
 	}
 
-	/** TC_38408_05: an activated partner renders with the green background token. */
 	public boolean isPartnerStatusActivatedColourCoded() {
 		return hasStatusClass(ACTIVATED_STATUS_CLASS, ACTIVATED_STATUS_TEXT);
 	}
 
-	/** TC_38408_06: Deactivated renders with the grey background token. */
 	public boolean isPartnerStatusDeactivatedColourCoded() {
 		return hasStatusClass(DEACTIVATED_STATUS_CLASS, DEACTIVATED_STATUS_TEXT);
 	}
@@ -173,8 +143,8 @@ public class IndividualViewPage extends BasePage {
 				return false;
 			}
 			if (actualClass == null || !actualClass.contains(expectedClass)) {
-				LogUtil.error("Partner Status '" + expectedStatus + "' missing the expected colour token "
-						+ expectedClass);
+				LogUtil.error(
+						"Partner Status '" + expectedStatus + "' missing the expected colour token " + expectedClass);
 				takeScreenshot();
 				return false;
 			}
@@ -187,15 +157,6 @@ public class IndividualViewPage extends BasePage {
 		}
 	}
 
-	// --- Keyboard accessibility (TC_38408_13) ---
-
-	/**
-	 * TC_38408_13: reaches the Approve/Reject button with Tab and triggers it with
-	 * Enter, without using the mouse.
-	 *
-	 * Tabbing starts from the document body so the walk mirrors what a keyboard
-	 * user does on landing, and it is bounded so a layout change cannot spin here.
-	 */
 	public boolean openApproveRejectPopupUsingKeyboard() {
 		WebElement button = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
 				.until(ExpectedConditions.visibilityOfElementLocated(APPROVE_REJECT_BUTTON));
@@ -216,7 +177,6 @@ public class IndividualViewPage extends BasePage {
 		return opened;
 	}
 
-	/** TC_38408_13: Approve and Reject inside the popup are keyboard reachable. */
 	public boolean areApproveRejectPopupButtonsKeyboardReachable() {
 		if (tabUntilFocused(APPROVE_BUTTON_ID, REJECT_BUTTON_ID)) {
 			return true;
@@ -226,12 +186,6 @@ public class IndividualViewPage extends BasePage {
 		return false;
 	}
 
-	/**
-	 * TC_38408_13: the popup is dismissible from the keyboard.
-	 *
-	 * Closes the popup through the close icon when Escape does not, so the caller
-	 * is left on a clean page either way, and reports the Escape result.
-	 */
 	public boolean closeApproveRejectPopupUsingEscape() {
 		driver.switchTo().activeElement().sendKeys(Keys.ESCAPE);
 
@@ -244,10 +198,6 @@ public class IndividualViewPage extends BasePage {
 		return !stillOpen;
 	}
 
-	/**
-	 * Presses Tab until one of the given element ids holds the focus. Returns false
-	 * once the budget is spent, leaving the focus wherever it landed.
-	 */
 	private boolean tabUntilFocused(String... targetIds) {
 		for (int press = 0; press < MAX_TAB_PRESSES; press++) {
 			WebElement focused = driver.switchTo().activeElement();

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/IndividualViewPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/IndividualViewPage.java
@@ -1,0 +1,266 @@
+package io.mosip.testrig.pmpuiv2.pages;
+
+import java.time.Duration;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import io.mosip.testrig.pmpuiv2.kernel.util.ConfigManager;
+import io.mosip.testrig.pmpuiv2.utility.LogUtil;
+
+/**
+ * Approve/Reject controls rendered on the Partner Admin individual view pages.
+ *
+ * The button and the confirmation popup are the same components on every
+ * individual view that supports admin approval - Policies, FTM Chip,
+ * Authentication Services and SBI-Device - so one page object serves them all.
+ */
+public class IndividualViewPage extends BasePage {
+
+	private static final String APPROVE_REJECT_BUTTON_ID = "view_approve_reject_btn";
+	private static final String APPROVE_BUTTON_ID = "approve_btn";
+	private static final String REJECT_BUTTON_ID = "reject_btn";
+	private static final String APPROVE_REJECT_POPUP_TITLE_ID = "approve-reject_popup_title";
+
+	private static final By APPROVE_REJECT_BUTTON = By.id(APPROVE_REJECT_BUTTON_ID);
+	private static final By APPROVE_REJECT_POPUP_TITLE = By.id(APPROVE_REJECT_POPUP_TITLE_ID);
+
+	/** Upper bound on the tab walk, so a layout change cannot spin the test. */
+	private static final int MAX_TAB_PRESSES = 30;
+
+	/** Colour coding applied by bgOfStatus() in the portal's AppUtils. */
+	private static final String ACTIVATED_STATUS_CLASS = "bg-[#D1FADF]";
+	private static final String DEACTIVATED_STATUS_CLASS = "bg-[#EAECF0]";
+
+	/**
+	 * getStatusCode() renders an activated partner as 'Active', so that is the text
+	 * to expect on screen even though the story calls the state 'Activated'.
+	 */
+	private static final String ACTIVATED_STATUS_TEXT = "Active";
+	private static final String DEACTIVATED_STATUS_TEXT = "Deactivated";
+
+	@FindBy(id = APPROVE_REJECT_BUTTON_ID)
+	private WebElement individualViewApproveRejectButton;
+
+	@FindBy(id = APPROVE_REJECT_POPUP_TITLE_ID)
+	private WebElement approveRejectPopupTitle;
+
+	@FindBy(id = "approve-reject_popup_header")
+	private WebElement approveRejectPopupHeader;
+
+	@FindBy(id = "approve-reject_popup_description")
+	private WebElement approveRejectPopupDescription;
+
+	@FindBy(id = APPROVE_BUTTON_ID)
+	private WebElement approveButton;
+
+	@FindBy(id = REJECT_BUTTON_ID)
+	private WebElement rejectButton;
+
+	@FindBy(id = "approve_reject_popup_close_icon")
+	private WebElement approveRejectPopupCloseIcon;
+
+	@FindBy(id = "view_partner_policy_request_partner_status_label")
+	private WebElement partnerStatusLabel;
+
+	@FindBy(id = "view_partner_policy_request_partner_status_context")
+	private WebElement partnerStatusContext;
+
+	public IndividualViewPage(WebDriver driver) {
+		super(driver);
+	}
+
+	// --- Approve/Reject button (TC_38408_01, _02, _10, _14) ---
+
+	/** TC_38408_01: the button is rendered for a Pending for Approval record. */
+	public boolean isApproveRejectButtonDisplayed() {
+		return isElementDisplayed(individualViewApproveRejectButton);
+	}
+
+	/**
+	 * TC_38408_02 and TC_38408_14: the button is absent for records that cannot be
+	 * actioned. Probes briefly rather than waiting out the full timeout, since the
+	 * expected outcome is that nothing is there.
+	 */
+	public boolean isApproveRejectButtonAbsent() {
+		boolean present = isElementDisplayedQuick(APPROVE_REJECT_BUTTON, Duration.ofSeconds(5));
+		if (present) {
+			LogUtil.error("Approve/Reject button is rendered for a record that should not be actionable");
+			takeScreenshot();
+		}
+		return !present;
+	}
+
+	/** TC_38408_10: the button stays enabled for a deactivated partner. */
+	public boolean isApproveRejectButtonEnabled() {
+		return isElementEnabled(individualViewApproveRejectButton);
+	}
+
+	public void clickOnApproveRejectButton() {
+		clickOnElement(individualViewApproveRejectButton);
+	}
+
+	// --- Confirmation popup (TC_38408_03) ---
+
+	public boolean isApproveRejectPopupDisplayed() {
+		return isElementDisplayed(approveRejectPopupTitle);
+	}
+
+	public boolean isApproveRejectPopupHeaderDisplayed() {
+		return isElementDisplayed(approveRejectPopupHeader);
+	}
+
+	public boolean isApproveRejectPopupDescriptionDisplayed() {
+		return isElementDisplayed(approveRejectPopupDescription);
+	}
+
+	public boolean isApproveButtonDisplayed() {
+		return isElementDisplayed(approveButton);
+	}
+
+	public boolean isRejectButtonDisplayed() {
+		return isElementDisplayed(rejectButton);
+	}
+
+	public void clickOnApproveButton() {
+		clickOnElement(approveButton);
+	}
+
+	public void clickOnRejectButton() {
+		clickOnElement(rejectButton);
+	}
+
+	public void clickOnPopupCloseIcon() {
+		clickOnElement(approveRejectPopupCloseIcon);
+	}
+
+	// --- Partner Status field (TC_38408_04, _05, _06) ---
+
+	/** TC_38408_04: the field is present regardless of the record status. */
+	public boolean isPartnerStatusLabelDisplayed() {
+		return isElementDisplayed(partnerStatusLabel);
+	}
+
+	public String getPartnerStatus() {
+		return getTextFromLocator(partnerStatusContext).trim();
+	}
+
+	/** TC_38408_05: an activated partner renders with the green background token. */
+	public boolean isPartnerStatusActivatedColourCoded() {
+		return hasStatusClass(ACTIVATED_STATUS_CLASS, ACTIVATED_STATUS_TEXT);
+	}
+
+	/** TC_38408_06: Deactivated renders with the grey background token. */
+	public boolean isPartnerStatusDeactivatedColourCoded() {
+		return hasStatusClass(DEACTIVATED_STATUS_CLASS, DEACTIVATED_STATUS_TEXT);
+	}
+
+	private boolean hasStatusClass(String expectedClass, String expectedStatus) {
+		try {
+			waitForElementVisible(partnerStatusContext);
+			String actualClass = partnerStatusContext.getAttribute("class");
+			String actualStatus = partnerStatusContext.getText().trim();
+			LogUtil.step("Partner Status '" + actualStatus + "' rendered with class: " + actualClass);
+
+			if (!actualStatus.equalsIgnoreCase(expectedStatus)) {
+				LogUtil.error("Expected Partner Status '" + expectedStatus + "' but found '" + actualStatus + "'");
+				takeScreenshot();
+				return false;
+			}
+			if (actualClass == null || !actualClass.contains(expectedClass)) {
+				LogUtil.error("Partner Status '" + expectedStatus + "' missing the expected colour token "
+						+ expectedClass);
+				takeScreenshot();
+				return false;
+			}
+			return true;
+
+		} catch (Exception e) {
+			LogUtil.error("Failed to read the Partner Status colour coding: " + e.getClass().getSimpleName());
+			takeScreenshot();
+			return false;
+		}
+	}
+
+	// --- Keyboard accessibility (TC_38408_13) ---
+
+	/**
+	 * TC_38408_13: reaches the Approve/Reject button with Tab and triggers it with
+	 * Enter, without using the mouse.
+	 *
+	 * Tabbing starts from the document body so the walk mirrors what a keyboard
+	 * user does on landing, and it is bounded so a layout change cannot spin here.
+	 */
+	public boolean openApproveRejectPopupUsingKeyboard() {
+		WebElement button = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
+				.until(ExpectedConditions.visibilityOfElementLocated(APPROVE_REJECT_BUTTON));
+		scrollIntoView(button);
+
+		if (!tabUntilFocused(APPROVE_REJECT_BUTTON_ID)) {
+			LogUtil.error("Approve/Reject button was not reachable within " + MAX_TAB_PRESSES + " tab presses");
+			takeScreenshot();
+			return false;
+		}
+
+		driver.switchTo().activeElement().sendKeys(Keys.ENTER);
+		boolean opened = isElementDisplayedQuick(APPROVE_REJECT_POPUP_TITLE, Duration.ofSeconds(10));
+		if (!opened) {
+			LogUtil.error("Enter on the focused Approve/Reject button did not open the confirmation popup");
+			takeScreenshot();
+		}
+		return opened;
+	}
+
+	/** TC_38408_13: Approve and Reject inside the popup are keyboard reachable. */
+	public boolean areApproveRejectPopupButtonsKeyboardReachable() {
+		if (tabUntilFocused(APPROVE_BUTTON_ID, REJECT_BUTTON_ID)) {
+			return true;
+		}
+		LogUtil.error("Neither Approve nor Reject was reachable within " + MAX_TAB_PRESSES + " tab presses");
+		takeScreenshot();
+		return false;
+	}
+
+	/**
+	 * TC_38408_13: the popup is dismissible from the keyboard.
+	 *
+	 * Closes the popup through the close icon when Escape does not, so the caller
+	 * is left on a clean page either way, and reports the Escape result.
+	 */
+	public boolean closeApproveRejectPopupUsingEscape() {
+		driver.switchTo().activeElement().sendKeys(Keys.ESCAPE);
+
+		boolean stillOpen = isElementDisplayedQuick(APPROVE_REJECT_POPUP_TITLE, Duration.ofSeconds(5));
+		if (stillOpen) {
+			LogUtil.error("Escape did not dismiss the Approve/Reject popup");
+			takeScreenshot();
+			clickOnPopupCloseIcon();
+		}
+		return !stillOpen;
+	}
+
+	/**
+	 * Presses Tab until one of the given element ids holds the focus. Returns false
+	 * once the budget is spent, leaving the focus wherever it landed.
+	 */
+	private boolean tabUntilFocused(String... targetIds) {
+		for (int press = 0; press < MAX_TAB_PRESSES; press++) {
+			WebElement focused = driver.switchTo().activeElement();
+			String focusedId = focused.getAttribute("id");
+
+			for (String targetId : targetIds) {
+				if (targetId.equals(focusedId)) {
+					LogUtil.step("'" + targetId + "' holds the focus after " + press + " tab presses");
+					return true;
+				}
+			}
+			focused.sendKeys(Keys.TAB);
+		}
+		return false;
+	}
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/IndividualViewPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/IndividualViewPage.java
@@ -15,14 +15,6 @@ import io.mosip.testrig.pmpuiv2.utility.LogUtil;
 
 public class IndividualViewPage extends BasePage {
 
-	private static final String APPROVE_REJECT_BUTTON_ID = "view_approve_reject_btn";
-	private static final String APPROVE_BUTTON_ID = "approve_btn";
-	private static final String REJECT_BUTTON_ID = "reject_btn";
-	private static final String APPROVE_REJECT_POPUP_TITLE_ID = "approve-reject_popup_title";
-
-	private static final By APPROVE_REJECT_BUTTON = By.id(APPROVE_REJECT_BUTTON_ID);
-	private static final By APPROVE_REJECT_POPUP_TITLE = By.id(APPROVE_REJECT_POPUP_TITLE_ID);
-
 	private static final int MAX_TAB_PRESSES = 30;
 
 	private static final String ACTIVATED_STATUS_CLASS = "bg-[#D1FADF]";
@@ -30,10 +22,10 @@ public class IndividualViewPage extends BasePage {
 	private static final String ACTIVATED_STATUS_TEXT = "Active";
 	private static final String DEACTIVATED_STATUS_TEXT = "Deactivated";
 
-	@FindBy(id = APPROVE_REJECT_BUTTON_ID)
+	@FindBy(id = "view_approve_reject_btn")
 	private WebElement individualViewApproveRejectButton;
 
-	@FindBy(id = APPROVE_REJECT_POPUP_TITLE_ID)
+	@FindBy(id = "approve-reject_popup_title")
 	private WebElement approveRejectPopupTitle;
 
 	@FindBy(id = "approve-reject_popup_header")
@@ -42,10 +34,10 @@ public class IndividualViewPage extends BasePage {
 	@FindBy(id = "approve-reject_popup_description")
 	private WebElement approveRejectPopupDescription;
 
-	@FindBy(id = APPROVE_BUTTON_ID)
+	@FindBy(id = "approve_btn")
 	private WebElement approveButton;
 
-	@FindBy(id = REJECT_BUTTON_ID)
+	@FindBy(id = "reject_btn")
 	private WebElement rejectButton;
 
 	@FindBy(id = "approve_reject_popup_close_icon")
@@ -66,7 +58,7 @@ public class IndividualViewPage extends BasePage {
 	}
 
 	public boolean isApproveRejectButtonAbsent() {
-		boolean present = isElementDisplayedQuick(APPROVE_REJECT_BUTTON, Duration.ofSeconds(5));
+		boolean present = isElementDisplayedQuick(By.id("view_approve_reject_btn"), Duration.ofSeconds(5));
 		if (present) {
 			LogUtil.error("Approve/Reject button is rendered for a record that should not be actionable");
 			takeScreenshot();
@@ -158,18 +150,18 @@ public class IndividualViewPage extends BasePage {
 	}
 
 	public boolean openApproveRejectPopupUsingKeyboard() {
-		WebElement button = new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
-				.until(ExpectedConditions.visibilityOfElementLocated(APPROVE_REJECT_BUTTON));
-		scrollIntoView(button);
+		new WebDriverWait(driver, Duration.ofSeconds(ConfigManager.getTimeout()))
+				.until(ExpectedConditions.visibilityOf(individualViewApproveRejectButton));
+		scrollIntoView(individualViewApproveRejectButton);
 
-		if (!tabUntilFocused(APPROVE_REJECT_BUTTON_ID)) {
+		if (!tabUntilFocused(individualViewApproveRejectButton)) {
 			LogUtil.error("Approve/Reject button was not reachable within " + MAX_TAB_PRESSES + " tab presses");
 			takeScreenshot();
 			return false;
 		}
 
 		driver.switchTo().activeElement().sendKeys(Keys.ENTER);
-		boolean opened = isElementDisplayedQuick(APPROVE_REJECT_POPUP_TITLE, Duration.ofSeconds(10));
+		boolean opened = isElementDisplayedQuick(By.id("approve-reject_popup_title"), Duration.ofSeconds(10));
 		if (!opened) {
 			LogUtil.error("Enter on the focused Approve/Reject button did not open the confirmation popup");
 			takeScreenshot();
@@ -178,7 +170,7 @@ public class IndividualViewPage extends BasePage {
 	}
 
 	public boolean areApproveRejectPopupButtonsKeyboardReachable() {
-		if (tabUntilFocused(APPROVE_BUTTON_ID, REJECT_BUTTON_ID)) {
+		if (tabUntilFocused(approveButton, rejectButton)) {
 			return true;
 		}
 		LogUtil.error("Neither Approve nor Reject was reachable within " + MAX_TAB_PRESSES + " tab presses");
@@ -189,7 +181,7 @@ public class IndividualViewPage extends BasePage {
 	public boolean closeApproveRejectPopupUsingEscape() {
 		driver.switchTo().activeElement().sendKeys(Keys.ESCAPE);
 
-		boolean stillOpen = isElementDisplayedQuick(APPROVE_REJECT_POPUP_TITLE, Duration.ofSeconds(5));
+		boolean stillOpen = isElementDisplayedQuick(By.id("approve-reject_popup_title"), Duration.ofSeconds(5));
 		if (stillOpen) {
 			LogUtil.error("Escape did not dismiss the Approve/Reject popup");
 			takeScreenshot();
@@ -198,13 +190,18 @@ public class IndividualViewPage extends BasePage {
 		return !stillOpen;
 	}
 
-	private boolean tabUntilFocused(String... targetIds) {
+	private boolean tabUntilFocused(WebElement... targets) {
+		String[] targetIds = new String[targets.length];
+		for (int i = 0; i < targets.length; i++) {
+			targetIds[i] = targets[i].getAttribute("id");
+		}
+
 		for (int press = 0; press < MAX_TAB_PRESSES; press++) {
 			WebElement focused = driver.switchTo().activeElement();
 			String focusedId = focused.getAttribute("id");
 
 			for (String targetId : targetIds) {
-				if (targetId.equals(focusedId)) {
+				if (targetId != null && targetId.equals(focusedId)) {
 					LogUtil.step("'" + targetId + "' holds the focus after " + press + " tab presses");
 					return true;
 				}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfDevicesPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfDevicesPage.java
@@ -45,6 +45,24 @@ public class ListOfDevicesPage extends BasePage {
 	@FindBy(id = "device_list_approve_reject_option")
 	private WebElement approveRejectButton;
 
+	@FindBy(id = "reject_popup_title")
+	private WebElement rejectOnlyPopupTitle;
+
+	@FindBy(id = "reject_popup_header")
+	private WebElement rejectOnlyPopupHeader;
+
+	@FindBy(id = "reject_popup_description")
+	private WebElement rejectOnlyPopupDescription;
+
+	@FindBy(id = "reject_popup_reject_btn")
+	private WebElement rejectOnlyPopupRejectButton;
+
+	@FindBy(id = "reject_popup_close_icon")
+	private WebElement rejectOnlyPopupCloseIcon;
+
+	@FindBy(xpath = "//tr[starts-with(@id,'device_list_item')]")
+	private List<WebElement> deviceRows;
+
 	@FindBy(id = "approve_btn")
 	private WebElement approveButton;
 
@@ -1258,37 +1276,24 @@ public class ListOfDevicesPage extends BasePage {
 	    return isDisplayed(deviceIdColumnHeader);
 	}
 
-	private static final By REJECT_ONLY_POPUP_TITLE = By.id("reject_popup_title");
-	private static final By REJECT_ONLY_POPUP_HEADER = By.id("reject_popup_header");
-	private static final By REJECT_ONLY_POPUP_DESCRIPTION = By.id("reject_popup_description");
-	private static final By REJECT_ONLY_POPUP_REJECT_BTN = By.id("reject_popup_reject_btn");
-	private static final By REJECT_ONLY_POPUP_CLOSE_ICON = By.id("reject_popup_close_icon");
-	private static final By APPROVE_BTN = By.id("approve_btn");
-	private static final By DEVICE_ROWS = By.xpath("//tr[starts-with(@id,'device_list_item')]");
-
-	private static final String LINKED_SBI_HEADER_ID = "sbiList.sbiId_header";
-	private static final String STATUS_HEADER_ID = "devicesList.status_header";
-
-	private static final String EMPTY_CELL_PLACEHOLDER = "-";
-
 	public boolean isRejectOnlyPopupDisplayed() {
-		return isDisplayed(REJECT_ONLY_POPUP_TITLE);
+		return isElementDisplayed(rejectOnlyPopupTitle);
 	}
 
 	public boolean isRejectOnlyPopupHeaderDisplayed() {
-		return isDisplayed(REJECT_ONLY_POPUP_HEADER);
+		return isElementDisplayed(rejectOnlyPopupHeader);
 	}
 
 	public boolean isRejectOnlyPopupDescriptionDisplayed() {
-		return isDisplayed(REJECT_ONLY_POPUP_DESCRIPTION);
+		return isElementDisplayed(rejectOnlyPopupDescription);
 	}
 
 	public boolean isRejectOnlyPopupRejectButtonDisplayed() {
-		return isDisplayed(REJECT_ONLY_POPUP_REJECT_BTN);
+		return isElementDisplayed(rejectOnlyPopupRejectButton);
 	}
 
 	public boolean isApproveButtonAbsentInRejectOnlyPopup() {
-		boolean present = isElementDisplayedQuick(APPROVE_BTN, Duration.ofSeconds(5));
+		boolean present = isElementDisplayedQuick(By.id("approve_btn"), Duration.ofSeconds(5));
 		if (present) {
 			LogUtil.error("An Approve button is offered for a device that is not linked to an SBI");
 			takeScreenshot();
@@ -1297,22 +1302,21 @@ public class ListOfDevicesPage extends BasePage {
 	}
 
 	public void clickOnRejectOnlyPopupCloseIcon() {
-		click(REJECT_ONLY_POPUP_CLOSE_ICON);
+		clickOnElement(rejectOnlyPopupCloseIcon);
 	}
 
 	public int findOrphanPendingDeviceRow() {
-		int linkedSbiColumn = getColumnIndex(LINKED_SBI_HEADER_ID);
-		int statusColumn = getColumnIndex(STATUS_HEADER_ID);
+		int linkedSbiColumn = getColumnIndex("sbiList.sbiId_header");
+		int statusColumn = getColumnIndex("devicesList.status_header");
 
 		if (linkedSbiColumn < 0 || statusColumn < 0) {
 			LogUtil.step("Linked SBI or Status column is not on this list, so no orphan device can be identified");
 			return -1;
 		}
 
-		List<WebElement> rows = driver.findElements(DEVICE_ROWS);
-		for (int i = 0; i < rows.size(); i++) {
+		for (int i = 0; i < deviceRows.size(); i++) {
 			try {
-				List<WebElement> cells = rows.get(i).findElements(By.tagName("td"));
+				List<WebElement> cells = deviceRows.get(i).findElements(By.tagName("td"));
 				if (cells.size() <= Math.max(linkedSbiColumn, statusColumn)) {
 					continue;
 				}
@@ -1337,7 +1341,7 @@ public class ListOfDevicesPage extends BasePage {
 	}
 
 	public boolean isLinkedSbiColumnEmpty(int rowNumber) {
-		int linkedSbiColumn = getColumnIndex(LINKED_SBI_HEADER_ID);
+		int linkedSbiColumn = getColumnIndex("sbiList.sbiId_header");
 		if (linkedSbiColumn < 0) {
 			LogUtil.error("Linked SBI column is not present on this list");
 			takeScreenshot();
@@ -1351,6 +1355,6 @@ public class ListOfDevicesPage extends BasePage {
 	}
 
 	private boolean isUnlinked(String linkedSbiCellValue) {
-		return linkedSbiCellValue.isEmpty() || EMPTY_CELL_PLACEHOLDER.equals(linkedSbiCellValue);
+		return linkedSbiCellValue.isEmpty() || "-".equals(linkedSbiCellValue);
 	}
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfDevicesPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfDevicesPage.java
@@ -1,12 +1,15 @@
 package io.mosip.testrig.pmpuiv2.pages;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -14,6 +17,7 @@ import org.openqa.selenium.support.FindBy;
 
 import io.mosip.testrig.pmpuiv2.fw.util.PmpTestUtil;
 import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+import io.mosip.testrig.pmpuiv2.utility.LogUtil;
 
 public class ListOfDevicesPage extends BasePage {
 
@@ -1254,5 +1258,122 @@ public class ListOfDevicesPage extends BasePage {
 	    return isDisplayed(deviceIdColumnHeader);
 	}
 
+	// ---------------------------------------------------------------
+	// Reject-only popup for devices not linked to an SBI (TC_38189_23)
+	// ---------------------------------------------------------------
 
+	/**
+	 * A device in Pending for Approval that carries no SBI gets the reject-only
+	 * RejectPopup instead of the usual ApproveRejectPopup, so the admin cannot
+	 * approve an unlinked device by accident.
+	 */
+	private static final By REJECT_ONLY_POPUP_TITLE = By.id("reject_popup_title");
+	private static final By REJECT_ONLY_POPUP_HEADER = By.id("reject_popup_header");
+	private static final By REJECT_ONLY_POPUP_DESCRIPTION = By.id("reject_popup_description");
+	private static final By REJECT_ONLY_POPUP_REJECT_BTN = By.id("reject_popup_reject_btn");
+	private static final By REJECT_ONLY_POPUP_CLOSE_ICON = By.id("reject_popup_close_icon");
+	// The popup's Reject action is deliberately not exposed here: rejecting would
+	// consume the orphaned device the rest of the suite relies on.
+	private static final By APPROVE_BTN = By.id("approve_btn");
+	private static final By DEVICE_ROWS = By.xpath("//tr[starts-with(@id,'device_list_item')]");
+
+	private static final String LINKED_SBI_HEADER_ID = "sbiList.sbiId_header";
+	private static final String STATUS_HEADER_ID = "devicesList.status_header";
+
+	/** The list renders a dash in place of a field the record does not carry. */
+	private static final String EMPTY_CELL_PLACEHOLDER = "-";
+
+	public boolean isRejectOnlyPopupDisplayed() {
+		return isDisplayed(REJECT_ONLY_POPUP_TITLE);
+	}
+
+	public boolean isRejectOnlyPopupHeaderDisplayed() {
+		return isDisplayed(REJECT_ONLY_POPUP_HEADER);
+	}
+
+	public boolean isRejectOnlyPopupDescriptionDisplayed() {
+		return isDisplayed(REJECT_ONLY_POPUP_DESCRIPTION);
+	}
+
+	public boolean isRejectOnlyPopupRejectButtonDisplayed() {
+		return isDisplayed(REJECT_ONLY_POPUP_REJECT_BTN);
+	}
+
+	/** The whole point of the reject-only popup: no Approve on offer. */
+	public boolean isApproveButtonAbsentInRejectOnlyPopup() {
+		boolean present = isElementDisplayedQuick(APPROVE_BTN, Duration.ofSeconds(5));
+		if (present) {
+			LogUtil.error("An Approve button is offered for a device that is not linked to an SBI");
+			takeScreenshot();
+		}
+		return !present;
+	}
+
+	public void clickOnRejectOnlyPopupCloseIcon() {
+		click(REJECT_ONLY_POPUP_CLOSE_ICON);
+	}
+
+	/**
+	 * Finds a device that is Pending for Approval and carries no linked SBI, which
+	 * is the state that triggers the reject-only popup. Returns the 1-based row
+	 * number, or -1 when the current page holds no such device.
+	 *
+	 * Column positions are read from the header row rather than hardcoded, because
+	 * the linked-devices view drops the SBI columns and so shifts every index.
+	 */
+	public int findOrphanPendingDeviceRow() {
+		int linkedSbiColumn = getColumnIndex(LINKED_SBI_HEADER_ID);
+		int statusColumn = getColumnIndex(STATUS_HEADER_ID);
+
+		if (linkedSbiColumn < 0 || statusColumn < 0) {
+			LogUtil.step("Linked SBI or Status column is not on this list, so no orphan device can be identified");
+			return -1;
+		}
+
+		List<WebElement> rows = driver.findElements(DEVICE_ROWS);
+		for (int i = 0; i < rows.size(); i++) {
+			try {
+				List<WebElement> cells = rows.get(i).findElements(By.tagName("td"));
+				if (cells.size() <= Math.max(linkedSbiColumn, statusColumn)) {
+					continue;
+				}
+
+				String linkedSbi = cells.get(linkedSbiColumn).getText().trim();
+				String status = cells.get(statusColumn).getText().trim();
+
+				if (isUnlinked(linkedSbi) && status.equalsIgnoreCase(GlobalConstants.PENDING_FOR_APPROVAL)) {
+					LogUtil.step("Orphan pending device found at row " + (i + 1));
+					return i + 1;
+				}
+			} catch (StaleElementReferenceException e) {
+				LogUtil.step("Row went stale while scanning for an orphan device; skipping row " + (i + 1));
+			}
+		}
+		LogUtil.step("No Pending for Approval device without a linked SBI on this page");
+		return -1;
+	}
+
+	/** Opens the action menu of the given 1-based device row. */
+	public void clickOnDeviceListActionMenu(int rowNumber) {
+		click(By.id("device_list_action_menu" + rowNumber));
+	}
+
+	/** The linked SBI cell of the given 1-based device row carries no value. */
+	public boolean isLinkedSbiColumnEmpty(int rowNumber) {
+		int linkedSbiColumn = getColumnIndex(LINKED_SBI_HEADER_ID);
+		if (linkedSbiColumn < 0) {
+			LogUtil.error("Linked SBI column is not present on this list");
+			takeScreenshot();
+			return false;
+		}
+
+		String value = getTextFromLocator(By.xpath(
+				"//tr[@id='device_list_item" + rowNumber + "']/td[" + (linkedSbiColumn + 1) + "]")).trim();
+		LogUtil.step("Linked SBI value at row " + rowNumber + ": '" + value + "'");
+		return isUnlinked(value);
+	}
+
+	private boolean isUnlinked(String linkedSbiCellValue) {
+		return linkedSbiCellValue.isEmpty() || EMPTY_CELL_PLACEHOLDER.equals(linkedSbiCellValue);
+	}
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfDevicesPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfDevicesPage.java
@@ -1258,29 +1258,17 @@ public class ListOfDevicesPage extends BasePage {
 	    return isDisplayed(deviceIdColumnHeader);
 	}
 
-	// ---------------------------------------------------------------
-	// Reject-only popup for devices not linked to an SBI (TC_38189_23)
-	// ---------------------------------------------------------------
-
-	/**
-	 * A device in Pending for Approval that carries no SBI gets the reject-only
-	 * RejectPopup instead of the usual ApproveRejectPopup, so the admin cannot
-	 * approve an unlinked device by accident.
-	 */
 	private static final By REJECT_ONLY_POPUP_TITLE = By.id("reject_popup_title");
 	private static final By REJECT_ONLY_POPUP_HEADER = By.id("reject_popup_header");
 	private static final By REJECT_ONLY_POPUP_DESCRIPTION = By.id("reject_popup_description");
 	private static final By REJECT_ONLY_POPUP_REJECT_BTN = By.id("reject_popup_reject_btn");
 	private static final By REJECT_ONLY_POPUP_CLOSE_ICON = By.id("reject_popup_close_icon");
-	// The popup's Reject action is deliberately not exposed here: rejecting would
-	// consume the orphaned device the rest of the suite relies on.
 	private static final By APPROVE_BTN = By.id("approve_btn");
 	private static final By DEVICE_ROWS = By.xpath("//tr[starts-with(@id,'device_list_item')]");
 
 	private static final String LINKED_SBI_HEADER_ID = "sbiList.sbiId_header";
 	private static final String STATUS_HEADER_ID = "devicesList.status_header";
 
-	/** The list renders a dash in place of a field the record does not carry. */
 	private static final String EMPTY_CELL_PLACEHOLDER = "-";
 
 	public boolean isRejectOnlyPopupDisplayed() {
@@ -1299,7 +1287,6 @@ public class ListOfDevicesPage extends BasePage {
 		return isDisplayed(REJECT_ONLY_POPUP_REJECT_BTN);
 	}
 
-	/** The whole point of the reject-only popup: no Approve on offer. */
 	public boolean isApproveButtonAbsentInRejectOnlyPopup() {
 		boolean present = isElementDisplayedQuick(APPROVE_BTN, Duration.ofSeconds(5));
 		if (present) {
@@ -1313,14 +1300,6 @@ public class ListOfDevicesPage extends BasePage {
 		click(REJECT_ONLY_POPUP_CLOSE_ICON);
 	}
 
-	/**
-	 * Finds a device that is Pending for Approval and carries no linked SBI, which
-	 * is the state that triggers the reject-only popup. Returns the 1-based row
-	 * number, or -1 when the current page holds no such device.
-	 *
-	 * Column positions are read from the header row rather than hardcoded, because
-	 * the linked-devices view drops the SBI columns and so shifts every index.
-	 */
 	public int findOrphanPendingDeviceRow() {
 		int linkedSbiColumn = getColumnIndex(LINKED_SBI_HEADER_ID);
 		int statusColumn = getColumnIndex(STATUS_HEADER_ID);
@@ -1353,12 +1332,10 @@ public class ListOfDevicesPage extends BasePage {
 		return -1;
 	}
 
-	/** Opens the action menu of the given 1-based device row. */
 	public void clickOnDeviceListActionMenu(int rowNumber) {
 		click(By.id("device_list_action_menu" + rowNumber));
 	}
 
-	/** The linked SBI cell of the given 1-based device row carries no value. */
 	public boolean isLinkedSbiColumnEmpty(int rowNumber) {
 		int linkedSbiColumn = getColumnIndex(LINKED_SBI_HEADER_ID);
 		if (linkedSbiColumn < 0) {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfSbiPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfSbiPage.java
@@ -866,4 +866,23 @@ public class ListOfSbiPage extends BasePage {
 		return isElementDisplayed(partnerIdInFirstColumn);
 	}
 
+	/**
+	 * Narrows the list to SBIs whose certificate has already expired, which is the
+	 * precondition for TC_38408_14.
+	 */
+	public void selectExpiredSbiExpiryStatusInFilter() {
+		click(By.id("sbi_expiry_status_filter_dropdown_btn"));
+		click(By.id("sbi_expiry_status_filter_option1"));
+	}
+
+	/** True when the filtered list returned at least one SBI. */
+	public boolean isAnySbiListed() {
+		return isElementDisplayedQuick(By.id("sbi_list_item1"), Duration.ofSeconds(10));
+	}
+
+	/** Opens the individual view of the first SBI in the filtered list. */
+	public void clickOnFirstSbiItem() {
+		clickOnElement(sbiListItem1);
+	}
+
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfSbiPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/ListOfSbiPage.java
@@ -866,21 +866,15 @@ public class ListOfSbiPage extends BasePage {
 		return isElementDisplayed(partnerIdInFirstColumn);
 	}
 
-	/**
-	 * Narrows the list to SBIs whose certificate has already expired, which is the
-	 * precondition for TC_38408_14.
-	 */
 	public void selectExpiredSbiExpiryStatusInFilter() {
 		click(By.id("sbi_expiry_status_filter_dropdown_btn"));
 		click(By.id("sbi_expiry_status_filter_option1"));
 	}
 
-	/** True when the filtered list returned at least one SBI. */
 	public boolean isAnySbiListed() {
 		return isElementDisplayedQuick(By.id("sbi_list_item1"), Duration.ofSeconds(10));
 	}
 
-	/** Opens the individual view of the first SBI in the filtered list. */
 	public void clickOnFirstSbiItem() {
 		clickOnElement(sbiListItem1);
 	}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/ApiKeyExpirationDateTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/ApiKeyExpirationDateTest.java
@@ -12,22 +12,9 @@ import io.mosip.testrig.pmpuiv2.pages.OidcClientPage;
 import io.mosip.testrig.pmpuiv2.utility.BaseClass;
 import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
 
-/**
- * Authentication Services: API Key expiration date in the individual (detailed)
- * view and the tabular view, for both the Authentication Partner and the
- * Partner Admin.
- *
- * Covers TC_40334_01 to TC_40334_10, TC_40334_13 and TC_40334_14.
- *
- * TC_40334_11 (Arabic) and TC_40334_12 (French) are not covered here. The suite
- * logs in through one fixed English session and the shared page objects locate
- * several elements by their English text, so a language switch would fail on
- * the locators rather than on the feature under test.
- */
 @Test(dependsOnGroups = { "ApiKeyAuthPartnerTest" }, groups = { "ApiKeyExpirationDateTest" })
 public class ApiKeyExpirationDateTest extends BaseClass {
 
-	/** The Partner Admin list, as opposed to the Authentication Partner list. */
 	private static final boolean ADMIN_VIEW = true;
 	private static final boolean PARTNER_VIEW = false;
 
@@ -36,16 +23,7 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 	private ApiKeyPage apiKeyPage;
 	private OidcClientPage oidcClientPage;
 
-	/**
-	 * TC_40334_01 navigate to the API Keys tab and see the tabular list.
-	 * TC_40334_02 'Expiration Date' column present, beside 'Creation Date'.
-	 * TC_40334_04 an active API Key row opens the individual view.
-	 * TC_40334_05 the date renders in the browser locale format.
-	 * TC_40334_06 the individual view field sequence ends with Expiration Date.
-	 * TC_40334_07 the column is visible to the Authentication Partner.
-	 * TC_40334_10 the field carries the same typography as its neighbours.
-	 */
-	@Test(priority = 1, description = "API Key expiration date in tabular and individual view as Authentication Partner")
+	@Test(priority = 1, description = "Verify API Key expiration date in tabular and individual view as Authentication Partner")
 	public void apiKeyExpirationDateAsAuthPartner() {
 
 		dashboardPage = new DashboardPage(driver);
@@ -53,7 +31,6 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 
 		loginAsAuthPartner();
 
-		// TC_40334_01: dashboard -> Authentication Services -> API Keys
 		assertTrue(dashboardPage.isAuthenticationServicesTitleDisplayed(),
 				GlobalConstants.isAuthenticationServicesDisplayed);
 		oidcClientPage = dashboardPage.clickOnAuthenticationServicesTitle();
@@ -61,29 +38,22 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		oidcClientPage.clickOnApiKeyTab();
 		assertTrue(apiKeyPage.isSubTitleOfTabularViewDisplayed(), GlobalConstants.isSubTitleOfTabularViewDisplayed);
 
-		// TC_40334_02 and TC_40334_07: column present and positioned after Creation Date
 		assertTrue(apiKeyPage.isCreationDateHeaderDisplayed(), GlobalConstants.isCreationDateHeaderDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderAfterCreationDate(),
 				GlobalConstants.isExpirationDateHeaderAfterCreationDate);
-
-		// TC_40334_05: browser locale date format
 		assertTrue(apiKeyPage.isExpirationDateSameAsBrowserDateFormat(PARTNER_VIEW),
 				GlobalConstants.isExpirationDateSameAsBrowserDateFormat);
 
-		// TC_40334_04: an active row opens the individual view
 		assertTrue(apiKeyPage.isApiListItem1Displayed(), GlobalConstants.isApiListDisplayed);
 		apiKeyPage.clickOnApiListItem1();
 		assertTrue(apiKeyPage.isApiKeyDetailsPageDisplayed(), GlobalConstants.isApiKeyDetailsPageDisplayed);
 
-		// TC_40334_06: Expiration Date present and last in the field sequence
 		assertTrue(apiKeyPage.isApiKeyDetailsExpirationDateLabelDisplayed(),
 				GlobalConstants.isApiKeyDetailsExpirationDateLabelDisplayed);
 		assertTrue(apiKeyPage.isApiKeyDetailsExpirationDateContextDisplayed(),
 				GlobalConstants.isApiKeyDetailsExpirationDateContextDisplayed);
 		assertTrue(apiKeyPage.isIndividualViewFieldOrderCorrect(), GlobalConstants.isIndividualViewFieldOrderCorrect);
-
-		// TC_40334_10: the field is styled like every other field on the page
 		assertTrue(apiKeyPage.isExpirationDateStyledLikeOtherFields(),
 				GlobalConstants.isExpirationDateStyledLikeOtherFields);
 
@@ -91,12 +61,7 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		assertTrue(apiKeyPage.isApiKeyListViewDisplayed(), GlobalConstants.isApiKeyListViewDisplayed);
 	}
 
-	/**
-	 * TC_40334_08 the expiry equals the creation date plus the configured duration.
-	 * TC_40334_09 after submitting, the user lands back on the tabular view with
-	 * the new key listed.
-	 */
-	@Test(priority = 2, description = "Redirect to the API Key tabular view after submitting API Key details", dependsOnMethods = "apiKeyExpirationDateAsAuthPartner")
+	@Test(priority = 2, description = "Verify redirect to the API Key tabular view after submitting API Key details", dependsOnMethods = "apiKeyExpirationDateAsAuthPartner")
 	public void redirectToTabularViewAfterSubmit() {
 
 		dashboardPage = new DashboardPage(driver);
@@ -114,29 +79,18 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		apiKeyPage.clickOnCopyIdCloseButton();
 		apiKeyPage.clickOnConfirmationGoBackButton();
 
-		// TC_40334_09: back on the list, with the submitted key visible
 		assertTrue(apiKeyPage.isApiKeyListViewDisplayed(), GlobalConstants.isApiKeyListViewDisplayed);
 		assertTrue(apiKeyPage.isApiListItem1Displayed(), GlobalConstants.isApiListDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
-
-		// TC_40334_08: expiry equals creation date plus the configured duration
 		assertTrue(
 				apiKeyPage.isExpirationDateOffsetFromCreationDate(ConfigManager.getApiKeyExpiryPeriodInDays(),
 						PARTNER_VIEW),
 				GlobalConstants.isExpirationDateOffsetFromCreationDate);
 	}
 
-	/**
-	 * TC_40334_02 'Expiration Date' column in the Partner Admin tabular view.
-	 * TC_40334_03 the column sorts ascending and descending.
-	 * TC_40334_05 the date renders in the browser locale format.
-	 * TC_40334_13 the individual view shows Expiration Date for Partner Admin.
-	 * TC_40334_14 rows open the individual view except those in Deactivated status.
-	 */
-	@Test(priority = 3, description = "API Key expiration date, sorting and row clickability as Partner Admin", dependsOnMethods = "redirectToTabularViewAfterSubmit")
+	@Test(priority = 3, description = "Verify API Key expiration date, sorting and row clickability as Partner Admin", dependsOnMethods = "redirectToTabularViewAfterSubmit")
 	public void apiKeyExpirationDateAsPartnerAdmin() {
 
-		// BaseClass.setUp() already signs this session in as the Partner Admin.
 		dashboardPage = new DashboardPage(driver);
 		apiKeyPage = new ApiKeyPage(driver);
 
@@ -146,17 +100,13 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		assertTrue(oidcClientPage.isApiKeyTabDisplayed(), GlobalConstants.isApiKeyTabDisplayed);
 		oidcClientPage.clickOnApiKeyTab();
 
-		// TC_40334_02: column present and beside Creation Date
 		assertTrue(apiKeyPage.isCreationDateHeaderDisplayed(), GlobalConstants.isCreationDateHeaderDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderAfterCreationDate(),
 				GlobalConstants.isExpirationDateHeaderAfterCreationDate);
-
-		// TC_40334_05: browser locale date format in the admin list
 		assertTrue(apiKeyPage.isExpirationDateSameAsBrowserDateFormat(ADMIN_VIEW),
 				GlobalConstants.isExpirationDateSameAsBrowserDateFormat);
 
-		// TC_40334_03: sort ascending then descending on Expiration Date
 		assertTrue(apiKeyPage.isExpiryDateAscIconDisplayed(), GlobalConstants.isExpiryDateAscIconDisplayed);
 		assertTrue(apiKeyPage.isExpiryDateDescIconDisplayed(), GlobalConstants.isExpiryDateDescIconDisplayed);
 
@@ -166,7 +116,6 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		apiKeyPage.clickOnExpiryDateDescIcon();
 		assertTrue(apiKeyPage.isExpiryDateColumnSorted(false, ADMIN_VIEW), GlobalConstants.isExpiryDateSortedDescending);
 
-		// TC_40334_13 and TC_40334_14: an active row opens the individual view
 		filterApiKeysByName(GlobalConstants.ACTIVATE_ADMINAPIKEY);
 		apiKeyPage.clickOnActivatedAdminApiKey();
 		assertTrue(apiKeyPage.isApiKeyDetailsPageDisplayed(), GlobalConstants.isApiKeyDetailsPageDisplayed);
@@ -176,13 +125,11 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 				GlobalConstants.isApiKeyDetailsExpirationDateContextDisplayed);
 		apiKeyPage.clickOnViewApiKeyBackButton();
 
-		// TC_40334_14: a Deactivated row must not open the individual view
 		filterApiKeysByName(GlobalConstants.DEACTIVATE_APIKEY);
 		assertTrue(apiKeyPage.isDeactivatedRowNotClickable(ADMIN_VIEW),
 				GlobalConstants.isDeactivatedApiKeyRowNotClickable);
 	}
 
-	/** Narrows the admin list to the API Key carrying the given name. */
 	private void filterApiKeysByName(String apiKeyName) {
 		apiKeyPage.clickOnFilterButton();
 		apiKeyPage.enterPartnerIdInFilter(GlobalConstants.AUTH_PARTNER_ID);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/ApiKeyExpirationDateTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/ApiKeyExpirationDateTest.java
@@ -1,0 +1,201 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.kernel.util.ConfigManager;
+import io.mosip.testrig.pmpuiv2.pages.ApiKeyPage;
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.LoginPage;
+import io.mosip.testrig.pmpuiv2.pages.OidcClientPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+
+/**
+ * Authentication Services: API Key expiration date in the individual (detailed)
+ * view and the tabular view, for both the Authentication Partner and the
+ * Partner Admin.
+ *
+ * Covers TC_40334_01 to TC_40334_10, TC_40334_13 and TC_40334_14.
+ *
+ * TC_40334_11 (Arabic) and TC_40334_12 (French) are not covered here. The suite
+ * logs in through one fixed English session and the shared page objects locate
+ * several elements by their English text, so a language switch would fail on
+ * the locators rather than on the feature under test.
+ */
+@Test(dependsOnGroups = { "ApiKeyAuthPartnerTest" }, groups = { "ApiKeyExpirationDateTest" })
+public class ApiKeyExpirationDateTest extends BaseClass {
+
+	/** The Partner Admin list, as opposed to the Authentication Partner list. */
+	private static final boolean ADMIN_VIEW = true;
+	private static final boolean PARTNER_VIEW = false;
+
+	private DashboardPage dashboardPage;
+	private LoginPage loginPage;
+	private ApiKeyPage apiKeyPage;
+	private OidcClientPage oidcClientPage;
+
+	/**
+	 * TC_40334_01 navigate to the API Keys tab and see the tabular list.
+	 * TC_40334_02 'Expiration Date' column present, beside 'Creation Date'.
+	 * TC_40334_04 an active API Key row opens the individual view.
+	 * TC_40334_05 the date renders in the browser locale format.
+	 * TC_40334_06 the individual view field sequence ends with Expiration Date.
+	 * TC_40334_07 the column is visible to the Authentication Partner.
+	 * TC_40334_10 the field carries the same typography as its neighbours.
+	 */
+	@Test(priority = 1, description = "API Key expiration date in tabular and individual view as Authentication Partner")
+	public void apiKeyExpirationDateAsAuthPartner() {
+
+		dashboardPage = new DashboardPage(driver);
+		apiKeyPage = new ApiKeyPage(driver);
+
+		loginAsAuthPartner();
+
+		// TC_40334_01: dashboard -> Authentication Services -> API Keys
+		assertTrue(dashboardPage.isAuthenticationServicesTitleDisplayed(),
+				GlobalConstants.isAuthenticationServicesDisplayed);
+		oidcClientPage = dashboardPage.clickOnAuthenticationServicesTitle();
+		assertTrue(oidcClientPage.isApiKeyTabDisplayed(), GlobalConstants.isApiKeyTabDisplayed);
+		oidcClientPage.clickOnApiKeyTab();
+		assertTrue(apiKeyPage.isSubTitleOfTabularViewDisplayed(), GlobalConstants.isSubTitleOfTabularViewDisplayed);
+
+		// TC_40334_02 and TC_40334_07: column present and positioned after Creation Date
+		assertTrue(apiKeyPage.isCreationDateHeaderDisplayed(), GlobalConstants.isCreationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderAfterCreationDate(),
+				GlobalConstants.isExpirationDateHeaderAfterCreationDate);
+
+		// TC_40334_05: browser locale date format
+		assertTrue(apiKeyPage.isExpirationDateSameAsBrowserDateFormat(PARTNER_VIEW),
+				GlobalConstants.isExpirationDateSameAsBrowserDateFormat);
+
+		// TC_40334_04: an active row opens the individual view
+		assertTrue(apiKeyPage.isApiListItem1Displayed(), GlobalConstants.isApiListDisplayed);
+		apiKeyPage.clickOnApiListItem1();
+		assertTrue(apiKeyPage.isApiKeyDetailsPageDisplayed(), GlobalConstants.isApiKeyDetailsPageDisplayed);
+
+		// TC_40334_06: Expiration Date present and last in the field sequence
+		assertTrue(apiKeyPage.isApiKeyDetailsExpirationDateLabelDisplayed(),
+				GlobalConstants.isApiKeyDetailsExpirationDateLabelDisplayed);
+		assertTrue(apiKeyPage.isApiKeyDetailsExpirationDateContextDisplayed(),
+				GlobalConstants.isApiKeyDetailsExpirationDateContextDisplayed);
+		assertTrue(apiKeyPage.isIndividualViewFieldOrderCorrect(), GlobalConstants.isIndividualViewFieldOrderCorrect);
+
+		// TC_40334_10: the field is styled like every other field on the page
+		assertTrue(apiKeyPage.isExpirationDateStyledLikeOtherFields(),
+				GlobalConstants.isExpirationDateStyledLikeOtherFields);
+
+		apiKeyPage.clickOnViewApiKeyBackButton();
+		assertTrue(apiKeyPage.isApiKeyListViewDisplayed(), GlobalConstants.isApiKeyListViewDisplayed);
+	}
+
+	/**
+	 * TC_40334_08 the expiry equals the creation date plus the configured duration.
+	 * TC_40334_09 after submitting, the user lands back on the tabular view with
+	 * the new key listed.
+	 */
+	@Test(priority = 2, description = "Redirect to the API Key tabular view after submitting API Key details", dependsOnMethods = "apiKeyExpirationDateAsAuthPartner")
+	public void redirectToTabularViewAfterSubmit() {
+
+		dashboardPage = new DashboardPage(driver);
+		apiKeyPage = new ApiKeyPage(driver);
+
+		loginAsAuthPartner();
+		oidcClientPage = dashboardPage.clickOnAuthenticationServicesTitle();
+		oidcClientPage.clickOnApiKeyTab();
+
+		apiKeyPage.clickOnCreateApiKey();
+		apiKeyPage.selectPartnerIdDropdown();
+		apiKeyPage.selectPolicyNameDropdown(GlobalConstants.DEFAULT_POLICY);
+		apiKeyPage.enterNameOfApiKeyTextBox(GlobalConstants.EXPIRY_APIKEY + BaseClass.data);
+		apiKeyPage.clickOnSubmitButton();
+		apiKeyPage.clickOnCopyIdCloseButton();
+		apiKeyPage.clickOnConfirmationGoBackButton();
+
+		// TC_40334_09: back on the list, with the submitted key visible
+		assertTrue(apiKeyPage.isApiKeyListViewDisplayed(), GlobalConstants.isApiKeyListViewDisplayed);
+		assertTrue(apiKeyPage.isApiListItem1Displayed(), GlobalConstants.isApiListDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
+
+		// TC_40334_08: expiry equals creation date plus the configured duration
+		assertTrue(
+				apiKeyPage.isExpirationDateOffsetFromCreationDate(ConfigManager.getApiKeyExpiryPeriodInDays(),
+						PARTNER_VIEW),
+				GlobalConstants.isExpirationDateOffsetFromCreationDate);
+	}
+
+	/**
+	 * TC_40334_02 'Expiration Date' column in the Partner Admin tabular view.
+	 * TC_40334_03 the column sorts ascending and descending.
+	 * TC_40334_05 the date renders in the browser locale format.
+	 * TC_40334_13 the individual view shows Expiration Date for Partner Admin.
+	 * TC_40334_14 rows open the individual view except those in Deactivated status.
+	 */
+	@Test(priority = 3, description = "API Key expiration date, sorting and row clickability as Partner Admin", dependsOnMethods = "redirectToTabularViewAfterSubmit")
+	public void apiKeyExpirationDateAsPartnerAdmin() {
+
+		// BaseClass.setUp() already signs this session in as the Partner Admin.
+		dashboardPage = new DashboardPage(driver);
+		apiKeyPage = new ApiKeyPage(driver);
+
+		assertTrue(dashboardPage.isAuthenticationServicesDisplayed(),
+				GlobalConstants.isAuthenticationServicesDisplayed);
+		oidcClientPage = dashboardPage.clickOnAuthenticationServices();
+		assertTrue(oidcClientPage.isApiKeyTabDisplayed(), GlobalConstants.isApiKeyTabDisplayed);
+		oidcClientPage.clickOnApiKeyTab();
+
+		// TC_40334_02: column present and beside Creation Date
+		assertTrue(apiKeyPage.isCreationDateHeaderDisplayed(), GlobalConstants.isCreationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderAfterCreationDate(),
+				GlobalConstants.isExpirationDateHeaderAfterCreationDate);
+
+		// TC_40334_05: browser locale date format in the admin list
+		assertTrue(apiKeyPage.isExpirationDateSameAsBrowserDateFormat(ADMIN_VIEW),
+				GlobalConstants.isExpirationDateSameAsBrowserDateFormat);
+
+		// TC_40334_03: sort ascending then descending on Expiration Date
+		assertTrue(apiKeyPage.isExpiryDateAscIconDisplayed(), GlobalConstants.isExpiryDateAscIconDisplayed);
+		assertTrue(apiKeyPage.isExpiryDateDescIconDisplayed(), GlobalConstants.isExpiryDateDescIconDisplayed);
+
+		apiKeyPage.clickOnExpiryDateAscIcon();
+		assertTrue(apiKeyPage.isExpiryDateColumnSorted(true, ADMIN_VIEW), GlobalConstants.isExpiryDateSortedAscending);
+
+		apiKeyPage.clickOnExpiryDateDescIcon();
+		assertTrue(apiKeyPage.isExpiryDateColumnSorted(false, ADMIN_VIEW), GlobalConstants.isExpiryDateSortedDescending);
+
+		// TC_40334_13 and TC_40334_14: an active row opens the individual view
+		filterApiKeysByName(GlobalConstants.ACTIVATE_ADMINAPIKEY);
+		apiKeyPage.clickOnActivatedAdminApiKey();
+		assertTrue(apiKeyPage.isApiKeyDetailsPageDisplayed(), GlobalConstants.isApiKeyDetailsPageDisplayed);
+		assertTrue(apiKeyPage.isApiKeyDetailsExpirationDateLabelDisplayed(),
+				GlobalConstants.isApiKeyDetailsExpirationDateLabelDisplayed);
+		assertTrue(apiKeyPage.isApiKeyDetailsExpirationDateContextDisplayed(),
+				GlobalConstants.isApiKeyDetailsExpirationDateContextDisplayed);
+		apiKeyPage.clickOnViewApiKeyBackButton();
+
+		// TC_40334_14: a Deactivated row must not open the individual view
+		filterApiKeysByName(GlobalConstants.DEACTIVATE_APIKEY);
+		assertTrue(apiKeyPage.isDeactivatedRowNotClickable(ADMIN_VIEW),
+				GlobalConstants.isDeactivatedApiKeyRowNotClickable);
+	}
+
+	/** Narrows the admin list to the API Key carrying the given name. */
+	private void filterApiKeysByName(String apiKeyName) {
+		apiKeyPage.clickOnFilterButton();
+		apiKeyPage.enterPartnerIdInFilter(GlobalConstants.AUTH_PARTNER_ID);
+		apiKeyPage.enterValidApiKeyNameInAdminFilter(apiKeyName);
+		apiKeyPage.clickOnApplyFilterButton();
+	}
+
+	private void loginAsAuthPartner() {
+		dashboardPage = new DashboardPage(driver);
+		dashboardPage.clickOnProfileDropdown();
+		loginPage = dashboardPage.clickOnLogoutButton();
+		loginPage.enterUserName(GlobalConstants.AUTH_PARTNER_ID);
+		loginPage.enterPassword(GlobalConstants.PARTNER_PASSWORD);
+		loginPage.clickOnLoginButton();
+	}
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/ApiKeyExpirationDateTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/ApiKeyExpirationDateTest.java
@@ -1,10 +1,10 @@
 package io.mosip.testrig.pmpuiv2.testcase;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
-import io.mosip.testrig.pmpuiv2.kernel.util.ConfigManager;
 import io.mosip.testrig.pmpuiv2.pages.ApiKeyPage;
 import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
 import io.mosip.testrig.pmpuiv2.pages.LoginPage;
@@ -39,7 +39,7 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		assertTrue(apiKeyPage.isSubTitleOfTabularViewDisplayed(), GlobalConstants.isSubTitleOfTabularViewDisplayed);
 
 		assertTrue(apiKeyPage.isCreationDateHeaderDisplayed(), GlobalConstants.isCreationDateHeaderDisplayed);
-		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isApiKeyExpirationDateHeaderDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderAfterCreationDate(),
 				GlobalConstants.isExpirationDateHeaderAfterCreationDate);
 		assertTrue(apiKeyPage.isExpirationDateSameAsBrowserDateFormat(PARTNER_VIEW),
@@ -81,11 +81,16 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 
 		assertTrue(apiKeyPage.isApiKeyListViewDisplayed(), GlobalConstants.isApiKeyListViewDisplayed);
 		assertTrue(apiKeyPage.isApiListItem1Displayed(), GlobalConstants.isApiListDisplayed);
-		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
-		assertTrue(
-				apiKeyPage.isExpirationDateOffsetFromCreationDate(ConfigManager.getApiKeyExpiryPeriodInDays(),
-						PARTNER_VIEW),
-				GlobalConstants.isExpirationDateOffsetFromCreationDate);
+		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isApiKeyExpirationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateNotBeforeCreationDate(PARTNER_VIEW),
+				GlobalConstants.isExpirationDateNotBeforeCreationDate);
+
+		String expirationDateInList = apiKeyPage.getExpirationDateFromList(PARTNER_VIEW);
+		apiKeyPage.clickOnApiListItem1();
+		assertTrue(apiKeyPage.isApiKeyDetailsPageDisplayed(), GlobalConstants.isApiKeyDetailsPageDisplayed);
+		assertEquals(apiKeyPage.getExpirationDateFromIndividualView(), expirationDateInList,
+				GlobalConstants.isExpirationDateConsistentAcrossViews);
+		apiKeyPage.clickOnViewApiKeyBackButton();
 	}
 
 	@Test(priority = 3, description = "Verify API Key expiration date, sorting and row clickability as Partner Admin", dependsOnMethods = "redirectToTabularViewAfterSubmit")
@@ -101,7 +106,7 @@ public class ApiKeyExpirationDateTest extends BaseClass {
 		oidcClientPage.clickOnApiKeyTab();
 
 		assertTrue(apiKeyPage.isCreationDateHeaderDisplayed(), GlobalConstants.isCreationDateHeaderDisplayed);
-		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isExpirationDateHeaderDisplayed);
+		assertTrue(apiKeyPage.isExpirationDateHeaderDisplayed(), GlobalConstants.isApiKeyExpirationDateHeaderDisplayed);
 		assertTrue(apiKeyPage.isExpirationDateHeaderAfterCreationDate(),
 				GlobalConstants.isExpirationDateHeaderAfterCreationDate);
 		assertTrue(apiKeyPage.isExpirationDateSameAsBrowserDateFormat(ADMIN_VIEW),

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/IndividualViewApproveRejectTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/IndividualViewApproveRejectTest.java
@@ -13,30 +13,6 @@ import io.mosip.testrig.pmpuiv2.pages.PartnerPolicyMappingPage;
 import io.mosip.testrig.pmpuiv2.utility.BaseClass;
 import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
 
-/**
- * Approve/Reject offered on the Partner Admin individual view pages wherever
- * admin approval or rejection applies.
- *
- * Covers TC_38408_01 to TC_38408_06, TC_38408_10, TC_38408_13 and TC_38408_14.
- *
- * Not covered here:
- *
- * TC_38408_07 asks for Chrome, Firefox, Edge and Safari. BaseClass.setUp()
- * builds a ChromeDriver unconditionally, so the suite has no other browser to
- * run against.
- *
- * TC_38408_08 and TC_38408_09 need two authenticated sessions alive at once to
- * produce an approve/reject collision. DriverManager hands out one WebDriver
- * per test method, so that state cannot be reached.
- *
- * TC_38408_11 (Arabic) and TC_38408_12 (French) need a language switch, which
- * the fixed English login and the text-based shared locators do not support.
- *
- * Every method starts from the dashboard of a freshly signed-in Partner Admin
- * session, because BaseClass.setUp() builds a new driver and logs in for each
- * one. The dashboard cards used to reach each section only exist on the
- * dashboard, so no method navigates from one section straight into another.
- */
 @Test(dependsOnGroups = { "PartnerPolicyMappingTest" }, groups = { "IndividualViewApproveRejectTest" })
 public class IndividualViewApproveRejectTest extends BaseClass {
 
@@ -50,46 +26,31 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 	private FtmPage ftmPage;
 	private ListOfSbiPage listOfSbiPage;
 
-	/**
-	 * TC_38408_01 Approve/Reject visible only for Pending for Approval records.
-	 * TC_38408_02 the buttons are absent for Approved and Rejected records.
-	 * TC_38408_04 'Partner Status' is present whatever the record status.
-	 */
-	@Test(priority = 1, description = "Approve/Reject button visibility by record status in the individual view")
+	@Test(priority = 1, description = "Verify Approve/Reject button visibility by record status in the individual view")
 	public void approveRejectVisibilityByRecordStatus() {
 
 		openPartnerPolicyLinking();
 
-		// TC_38408_01: pending record shows Approve/Reject
 		openPolicyRequestWithStatus(STATUS_PENDING);
 		assertTrue(individualViewPage.isApproveRejectButtonDisplayed(),
 				GlobalConstants.isIndividualViewApproveRejectButtonDisplayed);
-		// TC_38408_04: Partner Status present on a pending record
 		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
 		partnerPolicyMappingPage.clickOnViewBackButton();
 
-		// TC_38408_02: approved record hides Approve/Reject
 		openPolicyRequestWithStatus(STATUS_APPROVED);
 		assertTrue(individualViewPage.isApproveRejectButtonAbsent(),
 				GlobalConstants.isApproveRejectButtonAbsentForNonPendingRecord);
-		// TC_38408_04: Partner Status present on an approved record
 		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
 		partnerPolicyMappingPage.clickOnViewBackButton();
 
-		// TC_38408_02: rejected record hides Approve/Reject
 		openPolicyRequestWithStatus(STATUS_REJECTED);
 		assertTrue(individualViewPage.isApproveRejectButtonAbsent(),
 				GlobalConstants.isApproveRejectButtonAbsentForNonPendingRecord);
-		// TC_38408_04: Partner Status present on a rejected record
 		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
 		partnerPolicyMappingPage.clickOnViewBackButton();
 	}
 
-	/**
-	 * TC_38408_05 an activated partner's status carries the green colour coding.
-	 * TC_38408_10 Approve/Reject stays enabled for that record.
-	 */
-	@Test(priority = 2, description = "Partner Status Activated colour coding and Approve/Reject availability", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
+	@Test(priority = 2, description = "Verify Partner Status Activated colour coding and Approve/Reject availability", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
 	public void partnerStatusActivatedColourCoding() {
 
 		openPartnerPolicyLinking();
@@ -98,26 +59,16 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 		String partnerStatus = readPartnerStatus();
 		if (!GlobalConstants.PARTNER_STATUS_ACTIVE.equalsIgnoreCase(partnerStatus)) {
 			throw new SkipException("The first Pending for Approval request belongs to a partner in '" + partnerStatus
-					+ "' status, so the Activated colour coding of TC_38408_05 cannot be checked on it.");
+					+ "' status, so the Activated colour coding cannot be checked on it.");
 		}
 
-		// TC_38408_05: an activated partner renders green
 		assertTrue(individualViewPage.isPartnerStatusActivatedColourCoded(),
 				GlobalConstants.isPartnerStatusActivatedGreen);
-		// TC_38408_10: the buttons remain enabled, not greyed out
 		assertTrue(individualViewPage.isApproveRejectButtonEnabled(),
 				GlobalConstants.isIndividualViewApproveRejectButtonEnabled);
 	}
 
-	/**
-	 * TC_38408_06 Partner Status 'Deactivated' carries the grey colour coding.
-	 * TC_38408_10 Approve/Reject is still offered for a deactivated partner.
-	 *
-	 * Needs a pending policy request raised by a deactivated partner. The test
-	 * skips when the environment holds none, rather than reporting a pass it did
-	 * not earn.
-	 */
-	@Test(priority = 3, description = "Partner Status Deactivated colour coding and Approve/Reject availability", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
+	@Test(priority = 3, description = "Verify Partner Status Deactivated colour coding and Approve/Reject availability", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
 	public void partnerStatusDeactivatedColourCoding() {
 
 		openPartnerPolicyLinking();
@@ -126,23 +77,16 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 		String partnerStatus = readPartnerStatus();
 		if (!GlobalConstants.DEACTIVATED.equalsIgnoreCase(partnerStatus)) {
 			throw new SkipException("The first Pending for Approval request belongs to a partner in '" + partnerStatus
-					+ "' status, so the Deactivated colour coding of TC_38408_06 cannot be exercised. Deactivate a "
-					+ "partner holding a pending request to enable this check.");
+					+ "' status. Deactivate a partner holding a pending request to enable this check.");
 		}
 
-		// TC_38408_06: Deactivated renders grey
 		assertTrue(individualViewPage.isPartnerStatusDeactivatedColourCoded(),
 				GlobalConstants.isPartnerStatusDeactivatedGrey);
-		// TC_38408_10: still offered even though the partner is deactivated
 		assertTrue(individualViewPage.isApproveRejectButtonEnabled(),
 				GlobalConstants.isIndividualViewApproveRejectButtonEnabled);
 	}
 
-	/**
-	 * TC_38408_03 the individual view Approve/Reject opens the same confirmation
-	 * popup as the tabular view, carrying both the Approve and the Reject buttons.
-	 */
-	@Test(priority = 4, description = "Approve/Reject in the individual view opens the tabular-view confirmation popup", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
+	@Test(priority = 4, description = "Verify Approve/Reject in the individual view opens the confirmation popup", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
 	public void approveRejectPopupFromIndividualView() {
 
 		openPartnerPolicyLinking();
@@ -152,7 +96,6 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 				GlobalConstants.isIndividualViewApproveRejectButtonDisplayed);
 		individualViewPage.clickOnApproveRejectButton();
 
-		// TC_38408_03: the popup matches the tabular view - title, copy, both actions
 		assertTrue(individualViewPage.isApproveRejectPopupDisplayed(),
 				GlobalConstants.isIndividualViewApproveRejectPopupDisplayed);
 		assertTrue(individualViewPage.isApproveRejectPopupHeaderDisplayed(),
@@ -165,30 +108,21 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 		individualViewPage.clickOnPopupCloseIcon();
 	}
 
-	/**
-	 * TC_38408_13 the Approve/Reject action is completable without a mouse: Tab to
-	 * focus, Enter to open the popup, Tab to reach the popup buttons, Escape to
-	 * dismiss.
-	 */
-	@Test(priority = 5, description = "Keyboard access to the Approve/Reject buttons and confirmation popup", dependsOnMethods = "approveRejectPopupFromIndividualView")
+	@Test(priority = 5, description = "Verify keyboard access to the Approve/Reject buttons and confirmation popup", dependsOnMethods = "approveRejectPopupFromIndividualView")
 	public void approveRejectKeyboardAccessibility() {
 
 		openPartnerPolicyLinking();
 		openPolicyRequestWithStatus(STATUS_PENDING);
 
-		// TC_38408_13: Tab reaches the button and Enter opens the popup
 		assertTrue(individualViewPage.openApproveRejectPopupUsingKeyboard(),
 				GlobalConstants.isApproveRejectReachableByKeyboard);
-		// TC_38408_13: the popup's own buttons are reachable by Tab
 		assertTrue(individualViewPage.areApproveRejectPopupButtonsKeyboardReachable(),
 				GlobalConstants.isApproveRejectPopupButtonsKeyboardReachable);
-		// TC_38408_13: Escape dismisses the popup
 		assertTrue(individualViewPage.closeApproveRejectPopupUsingEscape(),
 				GlobalConstants.isApproveRejectPopupClosedByEscape);
 	}
 
-	/** TC_38408_01 and TC_38408_03 on the FTM Chip individual view. */
-	@Test(priority = 6, description = "Approve/Reject in the FTM Chip individual view", dependsOnMethods = "approveRejectPopupFromIndividualView")
+	@Test(priority = 6, description = "Verify Approve/Reject in the FTM Chip individual view", dependsOnMethods = "approveRejectPopupFromIndividualView")
 	public void approveRejectInFtmChipIndividualView() {
 
 		dashboardPage = new DashboardPage(driver);
@@ -205,8 +139,7 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 		verifyApproveRejectPopupOnCurrentIndividualView();
 	}
 
-	/** TC_38408_01 and TC_38408_03 on the SBI-Device individual view. */
-	@Test(priority = 7, description = "Approve/Reject in the SBI-Device individual view", dependsOnMethods = "approveRejectPopupFromIndividualView")
+	@Test(priority = 7, description = "Verify Approve/Reject in the SBI-Device individual view", dependsOnMethods = "approveRejectPopupFromIndividualView")
 	public void approveRejectInSbiIndividualView() {
 
 		dashboardPage = new DashboardPage(driver);
@@ -223,14 +156,7 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 		verifyApproveRejectPopupOnCurrentIndividualView();
 	}
 
-	/**
-	 * TC_38408_14 Approve/Reject must not be offered once an SBI has expired.
-	 *
-	 * The source test sheet records this scenario as Failing, so a failure here is
-	 * the open product defect rather than a broken test. Register the method name
-	 * in the known-issues list to have the suite skip it while the defect is open.
-	 */
-	@Test(priority = 8, description = "Approve/Reject is not offered for an expired SBI", dependsOnMethods = "approveRejectInSbiIndividualView")
+	@Test(priority = 8, description = "Verify Approve/Reject is not offered for an expired SBI", dependsOnMethods = "approveRejectInSbiIndividualView")
 	public void approveRejectNotOfferedForExpiredSbi() {
 
 		dashboardPage = new DashboardPage(driver);
@@ -245,18 +171,15 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 
 		if (!listOfSbiPage.isAnySbiListed()) {
 			throw new SkipException("No expired SBI exists for partner " + GlobalConstants.DEVICE_PARTNER_ID
-					+ ", so the expired-SBI rule of TC_38408_14 cannot be exercised. Seed an SBI with a past "
-					+ "expiry date to enable this check.");
+					+ ". Seed an SBI with a past expiry date to enable this check.");
 		}
 
 		listOfSbiPage.clickOnFirstSbiItem();
 
-		// TC_38408_14: expired SBI must not expose Approve/Reject
 		assertTrue(individualViewPage.isApproveRejectButtonAbsent(),
 				GlobalConstants.isApproveRejectButtonAbsentForExpiredSbi);
 	}
 
-	/** Lands on the Partner - Policy Linking list from the dashboard. */
 	private void openPartnerPolicyLinking() {
 		dashboardPage = new DashboardPage(driver);
 		partnerPolicyMappingPage = new PartnerPolicyMappingPage(driver);
@@ -267,13 +190,11 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 				GlobalConstants.isViewPartnerPolicyLinkingPageTitleDisplayed);
 	}
 
-	/** TC_38408_04: the Partner Status value shown on the individual view. */
 	private String readPartnerStatus() {
 		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
 		return individualViewPage.getPartnerStatus();
 	}
 
-	/** TC_38408_03: the confirmation popup carries both actions and then closes. */
 	private void verifyApproveRejectPopupOnCurrentIndividualView() {
 		assertTrue(individualViewPage.isApproveRejectButtonDisplayed(),
 				GlobalConstants.isIndividualViewApproveRejectButtonDisplayed);
@@ -287,12 +208,6 @@ public class IndividualViewApproveRejectTest extends BaseClass {
 		individualViewPage.clickOnPopupCloseIcon();
 	}
 
-	/**
-	 * Opens the first partner-policy request matching the requested status.
-	 *
-	 * Clears any filter still applied from an earlier call first, so a stale
-	 * selection cannot return a record in the wrong status.
-	 */
 	private void openPolicyRequestWithStatus(String status) {
 		if (partnerPolicyMappingPage.isFilterResetButtonEnabled()) {
 			partnerPolicyMappingPage.clickOnFilterResetButton();

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/IndividualViewApproveRejectTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/IndividualViewApproveRejectTest.java
@@ -1,0 +1,327 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertTrue;
+
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.FtmPage;
+import io.mosip.testrig.pmpuiv2.pages.IndividualViewPage;
+import io.mosip.testrig.pmpuiv2.pages.ListOfSbiPage;
+import io.mosip.testrig.pmpuiv2.pages.PartnerPolicyMappingPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+
+/**
+ * Approve/Reject offered on the Partner Admin individual view pages wherever
+ * admin approval or rejection applies.
+ *
+ * Covers TC_38408_01 to TC_38408_06, TC_38408_10, TC_38408_13 and TC_38408_14.
+ *
+ * Not covered here:
+ *
+ * TC_38408_07 asks for Chrome, Firefox, Edge and Safari. BaseClass.setUp()
+ * builds a ChromeDriver unconditionally, so the suite has no other browser to
+ * run against.
+ *
+ * TC_38408_08 and TC_38408_09 need two authenticated sessions alive at once to
+ * produce an approve/reject collision. DriverManager hands out one WebDriver
+ * per test method, so that state cannot be reached.
+ *
+ * TC_38408_11 (Arabic) and TC_38408_12 (French) need a language switch, which
+ * the fixed English login and the text-based shared locators do not support.
+ *
+ * Every method starts from the dashboard of a freshly signed-in Partner Admin
+ * session, because BaseClass.setUp() builds a new driver and logs in for each
+ * one. The dashboard cards used to reach each section only exist on the
+ * dashboard, so no method navigates from one section straight into another.
+ */
+@Test(dependsOnGroups = { "PartnerPolicyMappingTest" }, groups = { "IndividualViewApproveRejectTest" })
+public class IndividualViewApproveRejectTest extends BaseClass {
+
+	private static final String STATUS_PENDING = "pending";
+	private static final String STATUS_APPROVED = "approved";
+	private static final String STATUS_REJECTED = "rejected";
+
+	private DashboardPage dashboardPage;
+	private PartnerPolicyMappingPage partnerPolicyMappingPage;
+	private IndividualViewPage individualViewPage;
+	private FtmPage ftmPage;
+	private ListOfSbiPage listOfSbiPage;
+
+	/**
+	 * TC_38408_01 Approve/Reject visible only for Pending for Approval records.
+	 * TC_38408_02 the buttons are absent for Approved and Rejected records.
+	 * TC_38408_04 'Partner Status' is present whatever the record status.
+	 */
+	@Test(priority = 1, description = "Approve/Reject button visibility by record status in the individual view")
+	public void approveRejectVisibilityByRecordStatus() {
+
+		openPartnerPolicyLinking();
+
+		// TC_38408_01: pending record shows Approve/Reject
+		openPolicyRequestWithStatus(STATUS_PENDING);
+		assertTrue(individualViewPage.isApproveRejectButtonDisplayed(),
+				GlobalConstants.isIndividualViewApproveRejectButtonDisplayed);
+		// TC_38408_04: Partner Status present on a pending record
+		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
+		partnerPolicyMappingPage.clickOnViewBackButton();
+
+		// TC_38408_02: approved record hides Approve/Reject
+		openPolicyRequestWithStatus(STATUS_APPROVED);
+		assertTrue(individualViewPage.isApproveRejectButtonAbsent(),
+				GlobalConstants.isApproveRejectButtonAbsentForNonPendingRecord);
+		// TC_38408_04: Partner Status present on an approved record
+		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
+		partnerPolicyMappingPage.clickOnViewBackButton();
+
+		// TC_38408_02: rejected record hides Approve/Reject
+		openPolicyRequestWithStatus(STATUS_REJECTED);
+		assertTrue(individualViewPage.isApproveRejectButtonAbsent(),
+				GlobalConstants.isApproveRejectButtonAbsentForNonPendingRecord);
+		// TC_38408_04: Partner Status present on a rejected record
+		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
+		partnerPolicyMappingPage.clickOnViewBackButton();
+	}
+
+	/**
+	 * TC_38408_05 an activated partner's status carries the green colour coding.
+	 * TC_38408_10 Approve/Reject stays enabled for that record.
+	 */
+	@Test(priority = 2, description = "Partner Status Activated colour coding and Approve/Reject availability", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
+	public void partnerStatusActivatedColourCoding() {
+
+		openPartnerPolicyLinking();
+		openPolicyRequestWithStatus(STATUS_PENDING);
+
+		String partnerStatus = readPartnerStatus();
+		if (!GlobalConstants.PARTNER_STATUS_ACTIVE.equalsIgnoreCase(partnerStatus)) {
+			throw new SkipException("The first Pending for Approval request belongs to a partner in '" + partnerStatus
+					+ "' status, so the Activated colour coding of TC_38408_05 cannot be checked on it.");
+		}
+
+		// TC_38408_05: an activated partner renders green
+		assertTrue(individualViewPage.isPartnerStatusActivatedColourCoded(),
+				GlobalConstants.isPartnerStatusActivatedGreen);
+		// TC_38408_10: the buttons remain enabled, not greyed out
+		assertTrue(individualViewPage.isApproveRejectButtonEnabled(),
+				GlobalConstants.isIndividualViewApproveRejectButtonEnabled);
+	}
+
+	/**
+	 * TC_38408_06 Partner Status 'Deactivated' carries the grey colour coding.
+	 * TC_38408_10 Approve/Reject is still offered for a deactivated partner.
+	 *
+	 * Needs a pending policy request raised by a deactivated partner. The test
+	 * skips when the environment holds none, rather than reporting a pass it did
+	 * not earn.
+	 */
+	@Test(priority = 3, description = "Partner Status Deactivated colour coding and Approve/Reject availability", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
+	public void partnerStatusDeactivatedColourCoding() {
+
+		openPartnerPolicyLinking();
+		openPolicyRequestWithStatus(STATUS_PENDING);
+
+		String partnerStatus = readPartnerStatus();
+		if (!GlobalConstants.DEACTIVATED.equalsIgnoreCase(partnerStatus)) {
+			throw new SkipException("The first Pending for Approval request belongs to a partner in '" + partnerStatus
+					+ "' status, so the Deactivated colour coding of TC_38408_06 cannot be exercised. Deactivate a "
+					+ "partner holding a pending request to enable this check.");
+		}
+
+		// TC_38408_06: Deactivated renders grey
+		assertTrue(individualViewPage.isPartnerStatusDeactivatedColourCoded(),
+				GlobalConstants.isPartnerStatusDeactivatedGrey);
+		// TC_38408_10: still offered even though the partner is deactivated
+		assertTrue(individualViewPage.isApproveRejectButtonEnabled(),
+				GlobalConstants.isIndividualViewApproveRejectButtonEnabled);
+	}
+
+	/**
+	 * TC_38408_03 the individual view Approve/Reject opens the same confirmation
+	 * popup as the tabular view, carrying both the Approve and the Reject buttons.
+	 */
+	@Test(priority = 4, description = "Approve/Reject in the individual view opens the tabular-view confirmation popup", dependsOnMethods = "approveRejectVisibilityByRecordStatus")
+	public void approveRejectPopupFromIndividualView() {
+
+		openPartnerPolicyLinking();
+		openPolicyRequestWithStatus(STATUS_PENDING);
+
+		assertTrue(individualViewPage.isApproveRejectButtonDisplayed(),
+				GlobalConstants.isIndividualViewApproveRejectButtonDisplayed);
+		individualViewPage.clickOnApproveRejectButton();
+
+		// TC_38408_03: the popup matches the tabular view - title, copy, both actions
+		assertTrue(individualViewPage.isApproveRejectPopupDisplayed(),
+				GlobalConstants.isIndividualViewApproveRejectPopupDisplayed);
+		assertTrue(individualViewPage.isApproveRejectPopupHeaderDisplayed(),
+				GlobalConstants.isApproveRejectPopupTitleDisplayed);
+		assertTrue(individualViewPage.isApproveRejectPopupDescriptionDisplayed(),
+				GlobalConstants.isConfirmationPopupDetailedMessageDisplayed);
+		assertTrue(individualViewPage.isApproveButtonDisplayed(), GlobalConstants.isApproveButtonDisplayed);
+		assertTrue(individualViewPage.isRejectButtonDisplayed(), GlobalConstants.isRejectButtonDisplayed);
+
+		individualViewPage.clickOnPopupCloseIcon();
+	}
+
+	/**
+	 * TC_38408_13 the Approve/Reject action is completable without a mouse: Tab to
+	 * focus, Enter to open the popup, Tab to reach the popup buttons, Escape to
+	 * dismiss.
+	 */
+	@Test(priority = 5, description = "Keyboard access to the Approve/Reject buttons and confirmation popup", dependsOnMethods = "approveRejectPopupFromIndividualView")
+	public void approveRejectKeyboardAccessibility() {
+
+		openPartnerPolicyLinking();
+		openPolicyRequestWithStatus(STATUS_PENDING);
+
+		// TC_38408_13: Tab reaches the button and Enter opens the popup
+		assertTrue(individualViewPage.openApproveRejectPopupUsingKeyboard(),
+				GlobalConstants.isApproveRejectReachableByKeyboard);
+		// TC_38408_13: the popup's own buttons are reachable by Tab
+		assertTrue(individualViewPage.areApproveRejectPopupButtonsKeyboardReachable(),
+				GlobalConstants.isApproveRejectPopupButtonsKeyboardReachable);
+		// TC_38408_13: Escape dismisses the popup
+		assertTrue(individualViewPage.closeApproveRejectPopupUsingEscape(),
+				GlobalConstants.isApproveRejectPopupClosedByEscape);
+	}
+
+	/** TC_38408_01 and TC_38408_03 on the FTM Chip individual view. */
+	@Test(priority = 6, description = "Approve/Reject in the FTM Chip individual view", dependsOnMethods = "approveRejectPopupFromIndividualView")
+	public void approveRejectInFtmChipIndividualView() {
+
+		dashboardPage = new DashboardPage(driver);
+		individualViewPage = new IndividualViewPage(driver);
+		ftmPage = new FtmPage(driver);
+
+		dashboardPage.clickOnFTMChipTab();
+		ftmPage.clickOnFilterButton();
+		ftmPage.clickOnFtmStatusFilter();
+		ftmPage.clickOnFtmStatusFilterPendingForApproval();
+		ftmPage.clickOnApplyFilterButton();
+		ftmPage.clickOnFtmListItem1();
+
+		verifyApproveRejectPopupOnCurrentIndividualView();
+	}
+
+	/** TC_38408_01 and TC_38408_03 on the SBI-Device individual view. */
+	@Test(priority = 7, description = "Approve/Reject in the SBI-Device individual view", dependsOnMethods = "approveRejectPopupFromIndividualView")
+	public void approveRejectInSbiIndividualView() {
+
+		dashboardPage = new DashboardPage(driver);
+		individualViewPage = new IndividualViewPage(driver);
+		listOfSbiPage = new ListOfSbiPage(driver);
+
+		dashboardPage.clickOnSbiDevices();
+		listOfSbiPage.clickOnFilterButton();
+		listOfSbiPage.enterPartnerIdInFilter(GlobalConstants.DEVICE_PARTNER_ID);
+		listOfSbiPage.selectPendingForApprovalStatusInFilter();
+		listOfSbiPage.clickOnApplyFilterButton();
+		listOfSbiPage.clickOnPendingForApprovalSbiItem();
+
+		verifyApproveRejectPopupOnCurrentIndividualView();
+	}
+
+	/**
+	 * TC_38408_14 Approve/Reject must not be offered once an SBI has expired.
+	 *
+	 * The source test sheet records this scenario as Failing, so a failure here is
+	 * the open product defect rather than a broken test. Register the method name
+	 * in the known-issues list to have the suite skip it while the defect is open.
+	 */
+	@Test(priority = 8, description = "Approve/Reject is not offered for an expired SBI", dependsOnMethods = "approveRejectInSbiIndividualView")
+	public void approveRejectNotOfferedForExpiredSbi() {
+
+		dashboardPage = new DashboardPage(driver);
+		individualViewPage = new IndividualViewPage(driver);
+		listOfSbiPage = new ListOfSbiPage(driver);
+
+		dashboardPage.clickOnSbiDevices();
+		listOfSbiPage.clickOnFilterButton();
+		listOfSbiPage.enterPartnerIdInFilter(GlobalConstants.DEVICE_PARTNER_ID);
+		listOfSbiPage.selectExpiredSbiExpiryStatusInFilter();
+		listOfSbiPage.clickOnApplyFilterButton();
+
+		if (!listOfSbiPage.isAnySbiListed()) {
+			throw new SkipException("No expired SBI exists for partner " + GlobalConstants.DEVICE_PARTNER_ID
+					+ ", so the expired-SBI rule of TC_38408_14 cannot be exercised. Seed an SBI with a past "
+					+ "expiry date to enable this check.");
+		}
+
+		listOfSbiPage.clickOnFirstSbiItem();
+
+		// TC_38408_14: expired SBI must not expose Approve/Reject
+		assertTrue(individualViewPage.isApproveRejectButtonAbsent(),
+				GlobalConstants.isApproveRejectButtonAbsentForExpiredSbi);
+	}
+
+	/** Lands on the Partner - Policy Linking list from the dashboard. */
+	private void openPartnerPolicyLinking() {
+		dashboardPage = new DashboardPage(driver);
+		partnerPolicyMappingPage = new PartnerPolicyMappingPage(driver);
+		individualViewPage = new IndividualViewPage(driver);
+
+		dashboardPage.clickOnPartnerPolicyMappingTab();
+		assertTrue(partnerPolicyMappingPage.isPartnerPolicyLinkingTitleDisplayed(),
+				GlobalConstants.isViewPartnerPolicyLinkingPageTitleDisplayed);
+	}
+
+	/** TC_38408_04: the Partner Status value shown on the individual view. */
+	private String readPartnerStatus() {
+		assertTrue(individualViewPage.isPartnerStatusLabelDisplayed(), GlobalConstants.isPartnerStatusFieldDisplayed);
+		return individualViewPage.getPartnerStatus();
+	}
+
+	/** TC_38408_03: the confirmation popup carries both actions and then closes. */
+	private void verifyApproveRejectPopupOnCurrentIndividualView() {
+		assertTrue(individualViewPage.isApproveRejectButtonDisplayed(),
+				GlobalConstants.isIndividualViewApproveRejectButtonDisplayed);
+		individualViewPage.clickOnApproveRejectButton();
+
+		assertTrue(individualViewPage.isApproveRejectPopupDisplayed(),
+				GlobalConstants.isIndividualViewApproveRejectPopupDisplayed);
+		assertTrue(individualViewPage.isApproveButtonDisplayed(), GlobalConstants.isApproveButtonDisplayed);
+		assertTrue(individualViewPage.isRejectButtonDisplayed(), GlobalConstants.isRejectButtonDisplayed);
+
+		individualViewPage.clickOnPopupCloseIcon();
+	}
+
+	/**
+	 * Opens the first partner-policy request matching the requested status.
+	 *
+	 * Clears any filter still applied from an earlier call first, so a stale
+	 * selection cannot return a record in the wrong status.
+	 */
+	private void openPolicyRequestWithStatus(String status) {
+		if (partnerPolicyMappingPage.isFilterResetButtonEnabled()) {
+			partnerPolicyMappingPage.clickOnFilterResetButton();
+		}
+
+		partnerPolicyMappingPage.clickOnFilterButton();
+		partnerPolicyMappingPage.clickOnStatusFilterDropdown();
+
+		switch (status) {
+		case STATUS_PENDING:
+			partnerPolicyMappingPage.clickOnPendingForApprovalStatus();
+			partnerPolicyMappingPage.clickOnApplyFilterButton();
+			partnerPolicyMappingPage.clickOnPendingForApprovalPolicy();
+			break;
+		case STATUS_APPROVED:
+			partnerPolicyMappingPage.clickOnApprovedStatus();
+			partnerPolicyMappingPage.clickOnApplyFilterButton();
+			partnerPolicyMappingPage.clickOnApprovedPolicy();
+			break;
+		case STATUS_REJECTED:
+			partnerPolicyMappingPage.clickOnRejectedStatus();
+			partnerPolicyMappingPage.clickOnApplyFilterButton();
+			partnerPolicyMappingPage.clickOnRejectedPolicy();
+			break;
+		default:
+			throw new IllegalArgumentException("Unsupported policy request status: " + status);
+		}
+
+		assertTrue(partnerPolicyMappingPage.isPartnerPolicyDetailsPageDisplayed(),
+				GlobalConstants.isViewPartnerPolicyLinkingPageTitleDisplayed);
+	}
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/SbiDeviceProviderTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/SbiDeviceProviderTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import io.mosip.testrig.pmpuiv2.pages.AddDevicePage;
@@ -390,6 +391,52 @@ public class SbiDeviceProviderTest extends BaseClass {
 		verifyDeviceStatusInDeviceDetailsAsAdmin(GlobalConstants.FINGER, GlobalConstants.SLAP,
 				GlobalConstants.AUTOMATION_REJECTING, GlobalConstants.AUTOMATION_REJECTING, GlobalConstants.REJECTED);
 
+	}
+
+	/**
+	 * TC_38189_23: a device that is Pending for Approval but linked to no SBI must
+	 * offer Reject only, so the admin cannot approve an orphaned device.
+	 *
+	 * Devices created through the portal are always linked to an SBI, so this needs
+	 * an orphaned device already present in the environment. When the list holds
+	 * none the test skips rather than reporting a pass it did not earn.
+	 */
+	@Test(priority = 9, description = "Only Reject is offered for a device that is not linked to an SBI", dependsOnMethods = "verifyViewOfDevicesPageAsAdmin")
+	public void verifyRejectOnlyOptionForOrphanDevice() {
+		dashboardpage = new DashboardPage(driver);
+		listOfSbiPage = new ListOfSbiPage(driver);
+		listOfDevicesPage = new ListOfDevicesPage(driver);
+
+		dashboardpage.clickOnSbiDevices();
+		listOfSbiPage.clickOnDeviceTab();
+		assertTrue(listOfDevicesPage.isListOfDevicesTitleDisplayed(), GlobalConstants.isListOfDevicesTitleDisplayed);
+
+		int orphanRow = listOfDevicesPage.findOrphanPendingDeviceRow();
+		if (orphanRow < 0) {
+			throw new SkipException("No Pending for Approval device without a linked SBI exists in this "
+					+ "environment, so the reject-only popup of TC_38189_23 cannot be exercised. Seed an "
+					+ "orphaned device to enable this check.");
+		}
+
+		// Precondition 2: the linked SBI column carries no value for this device
+		assertTrue(listOfDevicesPage.isLinkedSbiColumnEmpty(orphanRow), GlobalConstants.isLinkedSbiColumnEmpty);
+
+		listOfDevicesPage.clickOnDeviceListActionMenu(orphanRow);
+		listOfDevicesPage.clickOnApproveOrReject();
+
+		// The reject-only popup replaces the usual approve/reject popup
+		assertTrue(listOfDevicesPage.isRejectOnlyPopupDisplayed(), GlobalConstants.isRejectOnlyPopupDisplayed);
+		assertTrue(listOfDevicesPage.isRejectOnlyPopupHeaderDisplayed(), GlobalConstants.isRejectOnlyPopupDisplayed);
+		assertTrue(listOfDevicesPage.isRejectOnlyPopupDescriptionDisplayed(),
+				GlobalConstants.isRejectOnlyPopupDescriptionDisplayed);
+		assertTrue(listOfDevicesPage.isRejectOnlyPopupRejectButtonDisplayed(),
+				GlobalConstants.isRejectOnlyPopupRejectButtonDisplayed);
+
+		// The point of the popup: no Approve is on offer
+		assertTrue(listOfDevicesPage.isApproveButtonAbsentInRejectOnlyPopup(),
+				GlobalConstants.isApproveButtonNotDisplayedForOrphanDevice);
+
+		listOfDevicesPage.clickOnRejectOnlyPopupCloseIcon();
 	}
 
 	private void loginAsDeviceProvider() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/SbiDeviceProviderTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/SbiDeviceProviderTest.java
@@ -393,14 +393,6 @@ public class SbiDeviceProviderTest extends BaseClass {
 
 	}
 
-	/**
-	 * TC_38189_23: a device that is Pending for Approval but linked to no SBI must
-	 * offer Reject only, so the admin cannot approve an orphaned device.
-	 *
-	 * Devices created through the portal are always linked to an SBI, so this needs
-	 * an orphaned device already present in the environment. When the list holds
-	 * none the test skips rather than reporting a pass it did not earn.
-	 */
 	@Test(priority = 9, description = "Only Reject is offered for a device that is not linked to an SBI", dependsOnMethods = "verifyViewOfDevicesPageAsAdmin")
 	public void verifyRejectOnlyOptionForOrphanDevice() {
 		dashboardpage = new DashboardPage(driver);
@@ -418,13 +410,11 @@ public class SbiDeviceProviderTest extends BaseClass {
 					+ "orphaned device to enable this check.");
 		}
 
-		// Precondition 2: the linked SBI column carries no value for this device
 		assertTrue(listOfDevicesPage.isLinkedSbiColumnEmpty(orphanRow), GlobalConstants.isLinkedSbiColumnEmpty);
 
 		listOfDevicesPage.clickOnDeviceListActionMenu(orphanRow);
 		listOfDevicesPage.clickOnApproveOrReject();
 
-		// The reject-only popup replaces the usual approve/reject popup
 		assertTrue(listOfDevicesPage.isRejectOnlyPopupDisplayed(), GlobalConstants.isRejectOnlyPopupDisplayed);
 		assertTrue(listOfDevicesPage.isRejectOnlyPopupHeaderDisplayed(), GlobalConstants.isRejectOnlyPopupDisplayed);
 		assertTrue(listOfDevicesPage.isRejectOnlyPopupDescriptionDisplayed(),
@@ -432,7 +422,6 @@ public class SbiDeviceProviderTest extends BaseClass {
 		assertTrue(listOfDevicesPage.isRejectOnlyPopupRejectButtonDisplayed(),
 				GlobalConstants.isRejectOnlyPopupRejectButtonDisplayed);
 
-		// The point of the popup: no Approve is on offer
 		assertTrue(listOfDevicesPage.isApproveButtonAbsentInRejectOnlyPopup(),
 				GlobalConstants.isApproveButtonNotDisplayedForOrphanDevice);
 

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -1725,14 +1725,15 @@ public class GlobalConstants {
 	public static final String EMAIL_ADDRESS_FILTER_INFO_TOOLTIP = "Note: This filter performs an exact match. Please enter the full email address (e.g., user@example.com) to find results.";
 	public static final String isEmailAddressFilterInfoIconDisplayed = "Verify the info icon is displayed alongside the email address filter textbox";
 	public static final String isEmailAddressFilterInfoTooltipCorrect = "Verify the info icon tooltip displays the exact match guidance text";
-	public static final String isExpirationDateHeaderDisplayed = "Verify if 'Expiration Date' column header displayed in the API Key tabular view";
+	public static final String isApiKeyExpirationDateHeaderDisplayed = "Verify if 'Expiration Date' column header displayed in the API Key tabular view";
 	public static final String isExpirationDateHeaderAfterCreationDate = "Verify if 'Expiration Date' column appears beside 'Creation Date'";
 	public static final String isExpiryDateDescIconDisplayed = "Verify if expiration date descending sort icon displayed";
 	public static final String isExpiryDateAscIconDisplayed = "Verify if expiration date ascending sort icon displayed";
 	public static final String isExpiryDateSortedAscending = "Verify if API Keys are sorted by expiration date in ascending order";
 	public static final String isExpiryDateSortedDescending = "Verify if API Keys are sorted by expiration date in descending order";
 	public static final String isExpirationDateSameAsBrowserDateFormat = "Verify if expiration date is displayed in the browser locale date format";
-	public static final String isExpirationDateOffsetFromCreationDate = "Verify if expiration date equals creation date plus the configured expiry duration";
+	public static final String isExpirationDateNotBeforeCreationDate = "Verify if the API Key expiration date is not earlier than its creation date";
+	public static final String isExpirationDateConsistentAcrossViews = "Verify if the API Key expiration date shown in the tabular view matches the individual view";
 	public static final String isApiKeyDetailsExpirationDateLabelDisplayed = "Verify if 'Expiration Date' label displayed in the individual API Key view";
 	public static final String isApiKeyDetailsExpirationDateContextDisplayed = "Verify if expiration date value displayed in the individual API Key view";
 	public static final String isIndividualViewFieldOrderCorrect = "Verify if individual API Key view renders its fields in the expected order ending with Expiration Date";

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -245,6 +245,7 @@ public class GlobalConstants {
 	public static final String DEACTIVATE_OIDCPOLICY2 = "deactivateoidcpolicy";
 	public static final String DEACTIVATE_APIKEY = "deactivateapikey";
 	public static final String ACTIVATE_ADMINAPIKEY = "activateadminapikey";
+	public static final String EXPIRY_APIKEY = "expiryapikey";
 	public static final String VIEW_DEVICE_TITLE = "View Device Details";
 
 	// MISP Partner
@@ -1724,5 +1725,42 @@ public class GlobalConstants {
 	public static final String EMAIL_ADDRESS_FILTER_INFO_TOOLTIP = "Note: This filter performs an exact match. Please enter the full email address (e.g., user@example.com) to find results.";
 	public static final String isEmailAddressFilterInfoIconDisplayed = "Verify the info icon is displayed alongside the email address filter textbox";
 	public static final String isEmailAddressFilterInfoTooltipCorrect = "Verify the info icon tooltip displays the exact match guidance text";
+
+	// API Key Expiration Date - individual and tabular view (TC_40334)
+	public static final String isExpirationDateHeaderDisplayed = "Verify if 'Expiration Date' column header displayed in the API Key tabular view";
+	public static final String isExpirationDateHeaderAfterCreationDate = "Verify if 'Expiration Date' column appears beside 'Creation Date'";
+	public static final String isExpiryDateDescIconDisplayed = "Verify if expiration date descending sort icon displayed";
+	public static final String isExpiryDateAscIconDisplayed = "Verify if expiration date ascending sort icon displayed";
+	public static final String isExpiryDateSortedAscending = "Verify if API Keys are sorted by expiration date in ascending order";
+	public static final String isExpiryDateSortedDescending = "Verify if API Keys are sorted by expiration date in descending order";
+	public static final String isExpirationDateSameAsBrowserDateFormat = "Verify if expiration date is displayed in the browser locale date format";
+	public static final String isExpirationDateOffsetFromCreationDate = "Verify if expiration date equals creation date plus the configured expiry duration";
+	public static final String isApiKeyDetailsExpirationDateLabelDisplayed = "Verify if 'Expiration Date' label displayed in the individual API Key view";
+	public static final String isApiKeyDetailsExpirationDateContextDisplayed = "Verify if expiration date value displayed in the individual API Key view";
+	public static final String isIndividualViewFieldOrderCorrect = "Verify if individual API Key view renders its fields in the expected order ending with Expiration Date";
+	public static final String isDeactivatedApiKeyRowNotClickable = "Verify if a Deactivated API Key row does not open the individual view";
+	public static final String isApiKeyListViewDisplayed = "Verify if the user lands on the API Key tabular view";
+	public static final String isExpirationDateStyledLikeOtherFields = "Verify if the Expiration Date field carries the same typography as the other individual view fields";
+
+	// Approve/Reject in individual view pages (TC_38408)
+	public static final String isIndividualViewApproveRejectButtonDisplayed = "Verify if Approve/Reject button displayed in the individual view page";
+	public static final String isIndividualViewApproveRejectButtonEnabled = "Verify if Approve/Reject button is enabled in the individual view page";
+	public static final String isApproveRejectButtonAbsentForNonPendingRecord = "Verify if Approve/Reject button is absent for a record that is not pending approval";
+	public static final String isApproveRejectButtonAbsentForExpiredSbi = "Verify if Approve/Reject button is absent for an expired SBI";
+	public static final String isApproveRejectPopupButtonsKeyboardReachable = "Verify if the Approve and Reject buttons inside the popup can be reached using the keyboard";
+	public static final String isIndividualViewApproveRejectPopupDisplayed = "Verify if the Approve/Reject confirmation popup is displayed from the individual view";
+	public static final String isPartnerStatusFieldDisplayed ="Verify if 'Partner Status' field displayed in the View Partner Policy Request page";
+	public static final String isPartnerStatusActivatedGreen = "Verify if Partner Status 'Activated' is rendered with the green colour coding";
+	public static final String isPartnerStatusDeactivatedGrey = "Verify if Partner Status 'Deactivated' is rendered with the grey colour coding";
+	public static final String isApproveRejectReachableByKeyboard = "Verify if the Approve/Reject button can be reached and triggered using the keyboard";
+	public static final String isApproveRejectPopupClosedByEscape = "Verify if the Approve/Reject popup can be dismissed using the Escape key";
+	public static final String isStaleRecordErrorDisplayed = "Verify if an error is shown when acting on a record that was already actioned";
+
+	// Orphan device reject-only popup (TC_38189)
+	public static final String isRejectOnlyPopupDisplayed = "Verify if the reject-only popup is displayed for a device not linked to an SBI";
+	public static final String isRejectOnlyPopupRejectButtonDisplayed = "Verify if the reject-only popup exposes the Reject button";
+	public static final String isApproveButtonNotDisplayedForOrphanDevice = "Verify if no Approve button is offered for a device not linked to an SBI";
+	public static final String isLinkedSbiColumnEmpty = "Verify if the linked SBI column is empty for an orphaned device";
+	public static final String isRejectOnlyPopupDescriptionDisplayed = "Verify if the reject-only popup shows the orphaned device description";
 
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -1725,8 +1725,6 @@ public class GlobalConstants {
 	public static final String EMAIL_ADDRESS_FILTER_INFO_TOOLTIP = "Note: This filter performs an exact match. Please enter the full email address (e.g., user@example.com) to find results.";
 	public static final String isEmailAddressFilterInfoIconDisplayed = "Verify the info icon is displayed alongside the email address filter textbox";
 	public static final String isEmailAddressFilterInfoTooltipCorrect = "Verify the info icon tooltip displays the exact match guidance text";
-
-	// API Key Expiration Date - individual and tabular view (TC_40334)
 	public static final String isExpirationDateHeaderDisplayed = "Verify if 'Expiration Date' column header displayed in the API Key tabular view";
 	public static final String isExpirationDateHeaderAfterCreationDate = "Verify if 'Expiration Date' column appears beside 'Creation Date'";
 	public static final String isExpiryDateDescIconDisplayed = "Verify if expiration date descending sort icon displayed";
@@ -1742,7 +1740,6 @@ public class GlobalConstants {
 	public static final String isApiKeyListViewDisplayed = "Verify if the user lands on the API Key tabular view";
 	public static final String isExpirationDateStyledLikeOtherFields = "Verify if the Expiration Date field carries the same typography as the other individual view fields";
 
-	// Approve/Reject in individual view pages (TC_38408)
 	public static final String isIndividualViewApproveRejectButtonDisplayed = "Verify if Approve/Reject button displayed in the individual view page";
 	public static final String isIndividualViewApproveRejectButtonEnabled = "Verify if Approve/Reject button is enabled in the individual view page";
 	public static final String isApproveRejectButtonAbsentForNonPendingRecord = "Verify if Approve/Reject button is absent for a record that is not pending approval";
@@ -1756,7 +1753,6 @@ public class GlobalConstants {
 	public static final String isApproveRejectPopupClosedByEscape = "Verify if the Approve/Reject popup can be dismissed using the Escape key";
 	public static final String isStaleRecordErrorDisplayed = "Verify if an error is shown when acting on a record that was already actioned";
 
-	// Orphan device reject-only popup (TC_38189)
 	public static final String isRejectOnlyPopupDisplayed = "Verify if the reject-only popup is displayed for a device not linked to an SBI";
 	public static final String isRejectOnlyPopupRejectButtonDisplayed = "Verify if the reject-only popup exposes the Reject button";
 	public static final String isApproveButtonNotDisplayedForOrphanDevice = "Verify if no Approve button is offered for a device not linked to an SBI";

--- a/uitest-pmp-v2/src/main/resources/testngFile/testng.xml
+++ b/uitest-pmp-v2/src/main/resources/testngFile/testng.xml
@@ -21,6 +21,7 @@
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PolicyCreationForAuthPartner" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.OidcClientAuthPartnerTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.ApiKeyAuthPartnerTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.ApiKeyExpirationDateTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.AuthPartnerWithoutCertificateTest" />
 			<!--DEVICE PARTNER FLOW-->
 			<class name="io.mosip.testrig.pmpuiv2.testcase.DevicePartnerCreation" />
@@ -55,6 +56,7 @@
 			<class name="io.mosip.testrig.pmpuiv2.testcase.DeactivatedFtmProviderTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.CertificateTrustStoreTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerPolicyMappingTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.IndividualViewApproveRejectTest" />
 
 			 <!--Deactivate PARTNER FLOW -->
 			<class name="io.mosip.testrig.pmpuiv2.testcase.DeactivatePartnerCreation" />


### PR DESCRIPTION
…te and individual view Approve/Reject

Adds UI coverage for three PMS stories, reusing the existing page-object structure rather than adding parallel scaffolding.

API Key Expiration Date (TC_40334_01 to _10, _13, _14)
- New ApiKeyExpirationDateTest covering the Authentication Partner and the Partner Admin views in three test methods.
- ApiKeyPage gains column-position, sorting, locale-format, field-order, typography and row-clickability checks for the Expiration Date column.

Approve/Reject in Individual View pages (TC_38408_01 to _06, _10, _13, _14)
- New IndividualViewPage serves Policies, FTM Chip, Authentication Services and SBI-Device, since all four render the same button and popup.
- New IndividualViewApproveRejectTest covers button visibility by record status, Partner Status colour coding, the confirmation popup and keyboard accessibility.

Orphaned device reject-only popup (TC_38189_23)
- SbiDeviceProviderTest asserts that a device with no linked SBI offers Reject only, so an unlinked device cannot be approved by accident.

Supporting changes
- BasePage.getColumnIndex() resolves a column by its "{i18nKey}_header" id instead of by visible header text, so column assertions do not depend on the display language.
- ConfigManager.getApiKeyExpiryPeriodInDays() mirrors the backend property mosip.pmp.partner.policy.expiry.period.indays, defaulting to the 100 year behaviour PMS applies when that property is unset. No config file is committed; the getter supplies the default.

Scenarios needing a second browser, a concurrent session, or an Arabic or French login are not included: the suite builds a single ChromeDriver per test method and logs in through a fixed English session. Checks that need environment data which may be absent raise SkipException with the seeding step required, rather than passing without asserting.