### PR TITLE
MOSIP-45491 - Automate List of Partners filter and email filter

### DIFF
--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -37,6 +37,7 @@ public class BasePage {
 
 	protected WebDriver driver;
 	protected static final int STALE_RETRY = 2;
+	private static final String REDACTED_VALUE = "***";
 	protected static final Logger logger = Logger.getLogger(BasePage.class);
 
 	public BasePage(WebDriver driver) {
@@ -146,7 +147,17 @@ public class BasePage {
 	}
 
 	public void enter(WebElement element, String value) {
-		LogUtil.action("Entering value '" + value + "' into element: ", element);
+		enterValue(element, value, value);
+	}
+
+	// Types the value but keeps it out of the logs and reports - for personal data such as
+	// the partner email addresses the filter tests read back from the live list.
+	public void enterRedacted(WebElement element, String value) {
+		enterValue(element, value, REDACTED_VALUE);
+	}
+
+	private void enterValue(WebElement element, String value, String loggedValue) {
+		LogUtil.action("Entering value '" + loggedValue + "' into element: ", element);
 		int attempts = 0;
 
 		while (attempts < STALE_RETRY) {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -547,6 +547,12 @@ public class BasePage {
 		new Actions(driver).sendKeys(Keys.ENTER).perform();
 	}
 
+	public void hoverOverElement(WebElement element) {
+		LogUtil.action("Hovering over element: ", element);
+		WaitUtil.waitForVisibility(driver, element);
+		new Actions(driver).moveToElement(element).perform();
+	}
+
 	// Focuses, then reports whether focus landed - a tabindex-less element leaves activeElement on body.
 	public boolean isElementFocusable(WebElement element) {
 		LogUtil.verify("Checking if element can take keyboard focus: ", element);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -786,10 +786,13 @@ public class PartnerAdminPage extends BasePage {
 		return getColumnValuesWithStaleRetry(By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[5]"));
 	}
 
+	// Waits for the cell rather than reading straight away: after a filter is applied or reset
+	// the rows are briefly absent, and consecutive scenarios in one session read across that gap.
 	private String getCellTextWithStaleRetry(By locator) {
 		for (int attempt = 1; attempt <= STALE_READ_RETRY; attempt++) {
 			try {
-				return driver.findElement(locator).getText().trim();
+				return new WebDriverWait(driver, LIST_LOAD_TIMEOUT)
+						.until(ExpectedConditions.visibilityOfElementLocated(locator)).getText().trim();
 			} catch (StaleElementReferenceException stale) {
 				LogUtil.step("Cell read went stale. Retry " + attempt + "/" + STALE_READ_RETRY);
 			}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -822,7 +822,7 @@ public class PartnerAdminPage extends BasePage {
 
 	public int getSortIconCountForColumn(String columnName) {
 		return getElementCount(By.xpath("//div[text()='" + columnName + "']/ancestor::th[1]"
-				+ "//*[contains(@id,'_asc_icon') or contains(@id,'_desc_icon')]"));
+				+ "//svg[contains(@id,'_asc_icon') or contains(@id,'_desc_icon')]"));
 	}
 
 	public String getEmailAddressFilterPlaceholder() {
@@ -846,7 +846,7 @@ public class PartnerAdminPage extends BasePage {
 	}
 
 	private static final By INVALID_CHARACTER_ERROR = By
-			.xpath("//*[starts-with(normalize-space(text()),'Invalid character.')]");
+			.xpath("//span[starts-with(normalize-space(text()),'Invalid character.')]");
 
 	public boolean isInvalidCharacterErrorDisplayed() {
 		return isElementDisplayedQuick(INVALID_CHARACTER_ERROR, SHORT_ABSENCE_TIMEOUT);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -827,7 +827,7 @@ public class PartnerAdminPage extends BasePage {
 	}
 
 	public void enterEmailAddressInFilter(String emailAddress) {
-		enter(emailsAddressFilter, emailAddress);
+		enterRedacted(emailsAddressFilter, emailAddress);
 	}
 
 	public boolean isEmailAddressFilterInfoIconDisplayed() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -101,7 +101,7 @@ public class PartnerAdminPage extends BasePage {
 	@FindBy(id = "partner_type_filter_label")
 	private WebElement partnersTypeFilter;
 
-	@FindBy(xpath = "//*[@id='partner_type_filter_dropdown_btn']/span")
+	@FindBy(xpath = "//button[@id='partner_type_filter_dropdown_btn']/span")
 	private WebElement partnerTypeDropdown;
 
 	@FindBy(id = "partner_organisation_filter")

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -1,11 +1,15 @@
 package io.mosip.testrig.pmpuiv2.pages;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -20,9 +24,10 @@ import io.mosip.testrig.pmpuiv2.utility.WaitUtil;
 
 public class PartnerAdminPage extends BasePage {
 
-	private static final Duration POPUP_ABSENCE_TIMEOUT = Duration.ofSeconds(3);
+	private static final Duration SHORT_ABSENCE_TIMEOUT = Duration.ofSeconds(3);
 	private static final Duration LIST_LOAD_TIMEOUT = Duration.ofSeconds(20);
 	private static final int POPUP_CENTRING_TOLERANCE_PX = 2;
+	private static final int STALE_READ_RETRY = 3;
 
 	@FindBy(id = "undefined_title")
 	private WebElement subTitleList;
@@ -104,6 +109,12 @@ public class PartnerAdminPage extends BasePage {
 
 	@FindBy(id = "email_address_filter")
 	private WebElement emailsAddressFilter;
+
+	@FindBy(id = "email_address_filter_info")
+	private WebElement emailAddressFilterInfoIcon;
+
+	@FindBy(id = "email_address_filter_info_info_description")
+	private WebElement emailAddressFilterInfoDescription;
 
 	@FindBy(xpath = "//span[normalize-space()='Select Cert. Upload Status']")
 	private WebElement certUploadsStatusFilter;
@@ -384,6 +395,14 @@ public class PartnerAdminPage extends BasePage {
 		return isElementDisplayed(partnerIdAscendingIcon);
 	}
 
+	public void clickOnPartnerIdAscendingIcon() {
+		clickOnElement(partnerIdAscendingIcon);
+	}
+
+	public void clickOnPartnerIdDescendingIcon() {
+		clickOnElement(partnerIdDescendingIcon);
+	}
+
 	public boolean isPolicyGroupNamesDescIconDisplayed() {
 		return isElementDisplayed(policyGroupNameDescendingIcon);
 	}
@@ -582,6 +601,36 @@ public class PartnerAdminPage extends BasePage {
 		}
 	}
 
+	public boolean isPartnerListLoadedByEmail(String expectedEmail) {
+		try {
+			new WebDriverWait(driver, LIST_LOAD_TIMEOUT).until(ExpectedConditions
+					.textToBePresentInElementLocated(By.xpath("//tr[@id='partner_list_item1']/td[5]"), expectedEmail));
+			return true;
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
+	public String getFirstRowPartnerType() {
+		return getCellTextWithStaleRetry(By.xpath("//tr[@id='partner_list_item1']/td[2]"));
+	}
+
+	public String getEmailOfFirstRowWithPartnerTypeOtherThan(String partnerType) {
+		List<String> partnerTypes = getColumnValuesWithStaleRetry(
+				By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[2]"));
+		List<String> emails = getEmailAddressColumnValues();
+		for (int row = 0; row < partnerTypes.size() && row < emails.size(); row++) {
+			if (!partnerType.equalsIgnoreCase(partnerTypes.get(row))) {
+				return emails.get(row);
+			}
+		}
+		throw new RuntimeException("No partner row found with a type other than: " + partnerType);
+	}
+
+	public void clickOnEmailAddressFilterInfoIcon() {
+		clickOnElement(emailAddressFilterInfoIcon);
+	}
+
 	// Row 1 is what the Action menu operates on; isDeactivatedPartnerRowDisplayed is pinned to row 2.
 	public boolean isFirstPartnerRowDisplayed() {
 		return isElementDisplayed(firstPartnerRow);
@@ -619,7 +668,7 @@ public class PartnerAdminPage extends BasePage {
 	}
 
 	public boolean isDeactivatePopupHeaderDisplayedQuick() {
-		return isElementDisplayedQuick(By.id("deactivate_popup_header"), POPUP_ABSENCE_TIMEOUT);
+		return isElementDisplayedQuick(By.id("deactivate_popup_header"), SHORT_ABSENCE_TIMEOUT);
 	}
 
 	public boolean isDeactivatePopupDescriptionDisplayed() {
@@ -723,6 +772,122 @@ public class PartnerAdminPage extends BasePage {
 
 	public int getPartnerRowCount() {
 		return getElementCount(By.xpath("//tr[starts-with(@id,'partner_list_item')]"));
+	}
+
+	public String getFirstRowPartnerId() {
+		return getCellTextWithStaleRetry(By.xpath("//tr[@id='partner_list_item1']/td[1]"));
+	}
+
+	public String getFirstRowEmailAddress() {
+		return getCellTextWithStaleRetry(By.xpath("//tr[@id='partner_list_item1']/td[5]"));
+	}
+
+	public List<String> getEmailAddressColumnValues() {
+		return getColumnValuesWithStaleRetry(By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[5]"));
+	}
+
+	private String getCellTextWithStaleRetry(By locator) {
+		for (int attempt = 1; attempt <= STALE_READ_RETRY; attempt++) {
+			try {
+				return driver.findElement(locator).getText().trim();
+			} catch (StaleElementReferenceException stale) {
+				LogUtil.step("Cell read went stale. Retry " + attempt + "/" + STALE_READ_RETRY);
+			}
+		}
+		throw new RuntimeException("Cell still stale after " + STALE_READ_RETRY + " retries: " + locator);
+	}
+
+	private List<String> getColumnValuesWithStaleRetry(By locator) {
+		for (int attempt = 1; attempt <= STALE_READ_RETRY; attempt++) {
+			try {
+				List<WebElement> cells = new WebDriverWait(driver, LIST_LOAD_TIMEOUT)
+						.until(ExpectedConditions.numberOfElementsToBeMoreThan(locator, 0));
+				List<String> values = new ArrayList<>();
+				for (WebElement cell : cells) {
+					values.add(cell.getText().trim());
+				}
+				return values;
+			} catch (StaleElementReferenceException stale) {
+				LogUtil.step("Column read went stale. Retry " + attempt + "/" + STALE_READ_RETRY);
+			} catch (TimeoutException noRows) {
+				LogUtil.step("No rows rendered for column: " + locator);
+				return new ArrayList<>();
+			}
+		}
+		throw new RuntimeException("Column still stale after " + STALE_READ_RETRY + " retries: " + locator);
+	}
+
+	public int getSortIconCountForColumn(String columnName) {
+		return getElementCount(By.xpath("//div[text()='" + columnName + "']/ancestor::th[1]"
+				+ "//*[contains(@id,'_asc_icon') or contains(@id,'_desc_icon')]"));
+	}
+
+	public String getEmailAddressFilterPlaceholder() {
+		return getTextFromAttribute(emailsAddressFilter, "placeholder");
+	}
+
+	public void enterEmailAddressInFilter(String emailAddress) {
+		enter(emailsAddressFilter, emailAddress);
+	}
+
+	public boolean isEmailAddressFilterInfoIconDisplayed() {
+		return isElementDisplayed(emailAddressFilterInfoIcon);
+	}
+
+	public void hoverOverEmailAddressFilterInfoIcon() {
+		hoverOverElement(emailAddressFilterInfoIcon);
+	}
+
+	public String getEmailAddressFilterInfoTooltipText() {
+		return getTextFromLocator(emailAddressFilterInfoDescription).trim();
+	}
+
+	private static final By INVALID_CHARACTER_ERROR = By
+			.xpath("//*[starts-with(normalize-space(text()),'Invalid character.')]");
+
+	public boolean isInvalidCharacterErrorDisplayed() {
+		return isElementDisplayedQuick(INVALID_CHARACTER_ERROR, SHORT_ABSENCE_TIMEOUT);
+	}
+
+	public String getInvalidCharacterErrorText() {
+		return getTextFromLocator(INVALID_CHARACTER_ERROR).trim();
+	}
+
+	public List<String> getPartnerIdColumnValues() {
+		return getColumnValuesWithStaleRetry(By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[1]"));
+	}
+
+	public boolean waitForFilteredCountToChangeFrom(int previousCount) {
+		try {
+			new WebDriverWait(driver, LIST_LOAD_TIMEOUT)
+					.until(driver -> getFilteredPartnersCountFromSubtitle() != previousCount);
+			return true;
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
+	public boolean waitForFirstRowPartnerIdToChangeFrom(String previousPartnerId) {
+		try {
+			new WebDriverWait(driver, LIST_LOAD_TIMEOUT)
+					.until(driver -> !previousPartnerId.equals(getFirstRowPartnerId()));
+			return true;
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
+	public int getFilteredPartnersCountFromSubtitle() {
+		String subtitle = getTextFromLocator(tabularViewsSubtitle).trim();
+		Matcher matcher = Pattern.compile("\\((\\d+)\\)").matcher(subtitle);
+		if (matcher.find()) {
+			return Integer.parseInt(matcher.group(1));
+		}
+		throw new RuntimeException("Filtered partner count not found in subtitle: " + subtitle);
+	}
+
+	public boolean isNoResultsFoundQuick() {
+		return isElementDisplayedQuick(By.xpath("//p[text()='No Results Found']"), SHORT_ABSENCE_TIMEOUT);
 	}
 
 	public String getPartnerStatusInViewPartnerDetails() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerEmailFilterTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerEmailFilterTest.java
@@ -1,0 +1,184 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.PartnerAdminPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+import io.mosip.testrig.pmpuiv2.utility.LogUtil;
+
+@Test(dependsOnGroups = { "PartnerDetailsTest" }, groups = { "PartnerEmailFilterTest" })
+public class PartnerEmailFilterTest extends BaseClass {
+
+	private DashboardPage dashboardPage;
+	private PartnerAdminPage partnerAdminPage;
+
+	@Test(priority = 1, description = "Verify Email Address column is visible in List of Partners")
+	public void emailAddressColumnHeaderIsVisible() {
+		navigateToPartnerListPage();
+
+		assertTrue(partnerAdminPage.isEmailAddressHeaderTagDisplayed(),
+				GlobalConstants.isEmailAddressColumnHeaderVisible);
+	}
+
+	@Test(priority = 2, description = "Verify the Email Address column is not sortable")
+	public void emailAddressColumnIsNotSortable() {
+		navigateToPartnerListPage();
+
+		assertTrue(partnerAdminPage.getSortIconCountForColumn(GlobalConstants.PARTNER_ID_COLUMN) > 0,
+				GlobalConstants.isSortIconLocatorValidForSortableColumn);
+
+		assertEquals(partnerAdminPage.getSortIconCountForColumn(GlobalConstants.EMAIL_ADDRESS_COLUMN), 0,
+				GlobalConstants.isEmailAddressColumnNotSortable);
+	}
+
+	@Test(priority = 3, description = "Verify the placeholder text for the email textbox")
+	public void emailAddressFilterPlaceholderIsCorrect() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		assertEquals(partnerAdminPage.getEmailAddressFilterPlaceholder(),
+				GlobalConstants.EMAIL_ADDRESS_FILTER_PLACEHOLDER,
+				GlobalConstants.isEmailAddressFilterPlaceholderCorrect);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 4, description = "Verify the info icon beside email address text")
+	public void emailAddressFilterInfoIconIsDisplayed() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		assertTrue(partnerAdminPage.isEmailAddressFilterInfoIconDisplayed(),
+				GlobalConstants.isEmailAddressFilterInfoIconDisplayed);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 5, description = "Verify info icon tooltip text")
+	public void emailAddressFilterInfoTooltipTextIsCorrect() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.clickOnEmailAddressFilterInfoIcon();
+
+		assertEquals(partnerAdminPage.getEmailAddressFilterInfoTooltipText(),
+				GlobalConstants.EMAIL_ADDRESS_FILTER_INFO_TOOLTIP,
+				GlobalConstants.isEmailAddressFilterInfoTooltipCorrect);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 6, description = "Verify exact match filtering using full email")
+	public void exactEmailMatchReturnsOnlyThatRecord() {
+		navigateToPartnerListPage();
+
+		String existingEmail = partnerAdminPage.getFirstRowEmailAddress();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterEmailAddressInFilter(existingEmail);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoadedByEmail(existingEmail), GlobalConstants.isPartnerListLoaded);
+
+		List<String> emailsAfterFilter = partnerAdminPage.getEmailAddressColumnValues();
+		assertEquals(emailsAfterFilter, List.of(existingEmail),
+				GlobalConstants.isExactEmailMatchReturningOnlyThatRecord);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 7, description = "Verify that searching with a partial email address shows no results")
+	public void partialEmailReturnsNoResults() {
+		navigateToPartnerListPage();
+
+		String partialEmail = partnerAdminPage.getFirstRowEmailAddress().split("@")[0] + "@";
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterEmailAddressInFilter(partialEmail);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isNoResultsFoundsDisplayed(), GlobalConstants.isPartialEmailReturningNoResults);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 8, description = "Verify email filter with non-existing full email")
+	public void nonExistingEmailReturnsNoResults() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterEmailAddressInFilter(GlobalConstants.NON_EXISTING_EMAIL);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isNoResultsFoundsDisplayed(), GlobalConstants.isNonExistingEmailReturningNoResults);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 9, description = "Verify the combined filtering with Email Address and other filters like Partner Type")
+	public void combinedEmailAndMismatchedPartnerTypeReturnsNoResults() {
+		navigateToPartnerListPage();
+
+		String conflictingEmail = partnerAdminPage
+				.getEmailOfFirstRowWithPartnerTypeOtherThan(GlobalConstants.AUTHENTICATION_PARTNER);
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterEmailAddressInFilter(conflictingEmail);
+		partnerAdminPage.clickOnPartnerTypeDropdown();
+		partnerAdminPage.clickOnAuthenticationPartner();
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isNoResultsFoundsDisplayed(),
+				GlobalConstants.isCombinedEmailAndPartnerTypeMismatchReturningNoResults);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 10, description = "Verify case sensitivity of email filter")
+	public void emailFilterIsNotCaseSensitive() {
+		navigateToPartnerListPage();
+
+		String existingEmail = partnerAdminPage.getFirstRowEmailAddress();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterEmailAddressInFilter(existingEmail.toUpperCase());
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoadedByEmail(existingEmail),
+				GlobalConstants.isEmailFilterCaseInsensitive);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 11, description = "Verify the email inputs with unsupported domains or special characters")
+	public void emailWithDisallowedSpecialCharactersShowsValidationError() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterEmailAddressInFilter(GlobalConstants.EMAIL_WITH_DISALLOWED_SPECIAL_CHARACTERS);
+
+		assertTrue(partnerAdminPage.isInvalidCharacterErrorDisplayed(),
+				GlobalConstants.isInvalidCharacterErrorDisplayed);
+		LogUtil.step("Invalid character message: " + partnerAdminPage.getInvalidCharacterErrorText());
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	private void navigateToPartnerListPage() {
+		dashboardPage = new DashboardPage(driver);
+		partnerAdminPage = new PartnerAdminPage(driver);
+
+		assertTrue(dashboardPage.isPartnersDisplayed(), GlobalConstants.isPartnersButtonDisplayed);
+		dashboardPage.clickOnPartners();
+		assertTrue(partnerAdminPage.isSubTitleListDisplayed(), GlobalConstants.isSubTitleListDisplayed);
+		assertTrue(partnerAdminPage.isPartnerListLoaded(), GlobalConstants.isPartnerListLoaded);
+	}
+
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerEmailFilterTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerEmailFilterTest.java
@@ -19,55 +19,38 @@ public class PartnerEmailFilterTest extends BaseClass {
 	private DashboardPage dashboardPage;
 	private PartnerAdminPage partnerAdminPage;
 
-	@Test(priority = 1, description = "Verify Email Address column is visible in List of Partners")
-	public void emailAddressColumnHeaderIsVisible() {
+	// The presentation checks all read the same screen, so they share one session rather than
+	// re-launching the browser and logging in again for each individual assertion.
+	@Test(priority = 1, description = "Verify the Email Address column and filter presentation: column visibility, "
+			+ "absence of sorting, filter placeholder, info icon and its tooltip")
+	public void emailAddressColumnAndFilterPresentation() {
 		navigateToPartnerListPage();
 
+		LogUtil.step("Scenario: Email Address column is visible in List of Partners");
 		assertTrue(partnerAdminPage.isEmailAddressHeaderTagDisplayed(),
 				GlobalConstants.isEmailAddressColumnHeaderVisible);
-	}
 
-	@Test(priority = 2, description = "Verify the Email Address column is not sortable")
-	public void emailAddressColumnIsNotSortable() {
-		navigateToPartnerListPage();
-
+		LogUtil.step("Scenario: Email Address column is not sortable");
+		// Confirms the lookup finds icons where they do exist, so an empty email result is meaningful.
 		assertTrue(partnerAdminPage.getSortIconCountForColumn(GlobalConstants.PARTNER_ID_COLUMN) > 0,
 				GlobalConstants.isSortIconLocatorValidForSortableColumn);
-
 		assertEquals(partnerAdminPage.getSortIconCountForColumn(GlobalConstants.EMAIL_ADDRESS_COLUMN), 0,
 				GlobalConstants.isEmailAddressColumnNotSortable);
-	}
-
-	@Test(priority = 3, description = "Verify the placeholder text for the email textbox")
-	public void emailAddressFilterPlaceholderIsCorrect() {
-		navigateToPartnerListPage();
 
 		partnerAdminPage.clickOnFilterButton();
+
+		LogUtil.step("Scenario: the email textbox placeholder text");
 		assertEquals(partnerAdminPage.getEmailAddressFilterPlaceholder(),
 				GlobalConstants.EMAIL_ADDRESS_FILTER_PLACEHOLDER,
 				GlobalConstants.isEmailAddressFilterPlaceholderCorrect);
 
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 4, description = "Verify the info icon beside email address text")
-	public void emailAddressFilterInfoIconIsDisplayed() {
-		navigateToPartnerListPage();
-
-		partnerAdminPage.clickOnFilterButton();
+		LogUtil.step("Scenario: the info icon beside the email address field");
 		assertTrue(partnerAdminPage.isEmailAddressFilterInfoIconDisplayed(),
 				GlobalConstants.isEmailAddressFilterInfoIconDisplayed);
 
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 5, description = "Verify info icon tooltip text")
-	public void emailAddressFilterInfoTooltipTextIsCorrect() {
-		navigateToPartnerListPage();
-
-		partnerAdminPage.clickOnFilterButton();
+		LogUtil.step("Scenario: the info icon tooltip text");
+		// The icon carries role="button"/tabindex="0", so the tooltip is toggled by activation, not hover.
 		partnerAdminPage.clickOnEmailAddressFilterInfoIcon();
-
 		assertEquals(partnerAdminPage.getEmailAddressFilterInfoTooltipText(),
 				GlobalConstants.EMAIL_ADDRESS_FILTER_INFO_TOOLTIP,
 				GlobalConstants.isEmailAddressFilterInfoTooltipCorrect);
@@ -75,16 +58,28 @@ public class PartnerEmailFilterTest extends BaseClass {
 		partnerAdminPage.clickOnFilterResetButton();
 	}
 
-	@Test(priority = 6, description = "Verify exact match filtering using full email")
-	public void exactEmailMatchReturnsOnlyThatRecord() {
+	@Test(priority = 2, description = "Verify the Email Address filter behaviour: exact match, partial and non-existing "
+			+ "addresses, a conflicting Partner Type, casing and disallowed special characters")
+	public void emailAddressFilterBehaviour() {
 		navigateToPartnerListPage();
 
+		verifyExactEmailMatchReturnsOnlyThatRecord();
+		verifyPartialEmailReturnsNoResults();
+		verifyNonExistingEmailReturnsNoResults();
+		verifyCombinedEmailAndMismatchedPartnerTypeReturnsNoResults();
+		verifyEmailFilterIsNotCaseSensitive();
+		verifyDisallowedSpecialCharactersShowValidationError();
+	}
+
+	private void verifyExactEmailMatchReturnsOnlyThatRecord() {
+		LogUtil.step("Scenario: exact match filtering using a full email address");
 		String existingEmail = partnerAdminPage.getFirstRowEmailAddress();
 
 		partnerAdminPage.clickOnFilterButton();
 		partnerAdminPage.enterEmailAddressInFilter(existingEmail);
 		partnerAdminPage.clickOnApplyFiltersBtn();
 
+		// Reading the column straight after Apply races the re-render and goes stale.
 		assertTrue(partnerAdminPage.isPartnerListLoadedByEmail(existingEmail), GlobalConstants.isPartnerListLoaded);
 
 		List<String> emailsAfterFilter = partnerAdminPage.getEmailAddressColumnValues();
@@ -94,10 +89,8 @@ public class PartnerEmailFilterTest extends BaseClass {
 		partnerAdminPage.clickOnFilterResetButton();
 	}
 
-	@Test(priority = 7, description = "Verify that searching with a partial email address shows no results")
-	public void partialEmailReturnsNoResults() {
-		navigateToPartnerListPage();
-
+	private void verifyPartialEmailReturnsNoResults() {
+		LogUtil.step("Scenario: a partial email address shows no results");
 		String partialEmail = partnerAdminPage.getFirstRowEmailAddress().split("@")[0] + "@";
 
 		partnerAdminPage.clickOnFilterButton();
@@ -109,10 +102,8 @@ public class PartnerEmailFilterTest extends BaseClass {
 		partnerAdminPage.clickOnFilterResetButton();
 	}
 
-	@Test(priority = 8, description = "Verify email filter with non-existing full email")
-	public void nonExistingEmailReturnsNoResults() {
-		navigateToPartnerListPage();
-
+	private void verifyNonExistingEmailReturnsNoResults() {
+		LogUtil.step("Scenario: a non-existing full email address shows no results");
 		partnerAdminPage.clickOnFilterButton();
 		partnerAdminPage.enterEmailAddressInFilter(GlobalConstants.NON_EXISTING_EMAIL);
 		partnerAdminPage.clickOnApplyFiltersBtn();
@@ -122,10 +113,10 @@ public class PartnerEmailFilterTest extends BaseClass {
 		partnerAdminPage.clickOnFilterResetButton();
 	}
 
-	@Test(priority = 9, description = "Verify the combined filtering with Email Address and other filters like Partner Type")
-	public void combinedEmailAndMismatchedPartnerTypeReturnsNoResults() {
-		navigateToPartnerListPage();
-
+	private void verifyCombinedEmailAndMismatchedPartnerTypeReturnsNoResults() {
+		LogUtil.step("Scenario: an email combined with a conflicting Partner Type shows no results");
+		// The email must belong to a non-Authentication partner, otherwise the two
+		// filters agree and the record legitimately comes back.
 		String conflictingEmail = partnerAdminPage
 				.getEmailOfFirstRowWithPartnerTypeOtherThan(GlobalConstants.AUTHENTICATION_PARTNER);
 
@@ -141,10 +132,8 @@ public class PartnerEmailFilterTest extends BaseClass {
 		partnerAdminPage.clickOnFilterResetButton();
 	}
 
-	@Test(priority = 10, description = "Verify case sensitivity of email filter")
-	public void emailFilterIsNotCaseSensitive() {
-		navigateToPartnerListPage();
-
+	private void verifyEmailFilterIsNotCaseSensitive() {
+		LogUtil.step("Scenario: the email filter is not case sensitive");
 		String existingEmail = partnerAdminPage.getFirstRowEmailAddress();
 
 		partnerAdminPage.clickOnFilterButton();
@@ -157,10 +146,8 @@ public class PartnerEmailFilterTest extends BaseClass {
 		partnerAdminPage.clickOnFilterResetButton();
 	}
 
-	@Test(priority = 11, description = "Verify the email inputs with unsupported domains or special characters")
-	public void emailWithDisallowedSpecialCharactersShowsValidationError() {
-		navigateToPartnerListPage();
-
+	private void verifyDisallowedSpecialCharactersShowValidationError() {
+		LogUtil.step("Scenario: an email with disallowed special characters is rejected");
 		partnerAdminPage.clickOnFilterButton();
 		partnerAdminPage.enterEmailAddressInFilter(GlobalConstants.EMAIL_WITH_DISALLOWED_SPECIAL_CHARACTERS);
 

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerFilterTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerFilterTest.java
@@ -13,6 +13,7 @@ import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
 import io.mosip.testrig.pmpuiv2.pages.PartnerAdminPage;
 import io.mosip.testrig.pmpuiv2.utility.BaseClass;
 import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+import io.mosip.testrig.pmpuiv2.utility.LogUtil;
 
 @Test(dependsOnGroups = { "PartnerDetailsTest" }, groups = { "PartnerFilterTest" })
 public class PartnerFilterTest extends BaseClass {
@@ -22,111 +23,29 @@ public class PartnerFilterTest extends BaseClass {
 	private DashboardPage dashboardPage;
 	private PartnerAdminPage partnerAdminPage;
 
-	@Test(priority = 1, description = "Verify the Results for the dropdown search without clicking on apply now")
-	public void dropdownSearchResultsNotDisplayedWithoutApplyNow() {
+	// Each test method spawns its own browser and login, so the filter scenarios share a
+	// single session and reset the panel between them rather than repeating that setup six times.
+	@Test(priority = 1, description = "Verify the filter section in List of Partners: dropdown search without Apply Now, "
+			+ "partial and case-insensitive text search, invalid values, applied results and the filtered count")
+	public void partnerListFilterBehaviour() {
 		navigateToPartnerListPage();
 
-		int baselineCount = partnerAdminPage.getPartnerRowCount();
-
-		partnerAdminPage.clickOnFilterButton();
-		partnerAdminPage.clickOnStatusFilter();
-		partnerAdminPage.clickOnDeActivatedStatusInFilters();
-
-		assertEquals(partnerAdminPage.getPartnerRowCount(), baselineCount,
-				GlobalConstants.isPartnerListUnchangedBeforeApplyingDropdownFilter);
-
-		partnerAdminPage.clickOnFilterResetButton();
+		verifyDropdownSelectionHasNoEffectBeforeApplyNow();
+		verifyPartialTextSearchReturnsRelatedResults();
+		verifyTextSearchIsCaseInsensitive();
+		verifyInvalidValuesShowErrorOnlyAfterApplyNow();
+		verifyApplyNowDisplaysFilteredResultsInTabularView();
+		verifyFilteredResultsCountDisplayedProperly();
 	}
 
-	@Test(priority = 2, description = "Verify the results entering set of letters for any of the text field")
-	public void textFieldPartialSearchReturnsRelatedResults() {
-		navigateToPartnerListPage();
-
-		String partialPartnerId = partnerAdminPage.getFirstRowPartnerId().substring(0, PARTIAL_SEARCH_LENGTH);
-
-		partnerAdminPage.clickOnFilterButton();
-		partnerAdminPage.enterPartnerIdInFilter(partialPartnerId);
-		partnerAdminPage.clickOnApplyFiltersBtn();
-
-		assertTrue(partnerAdminPage.isPartnerListLoaded(partialPartnerId),
-				GlobalConstants.isPartialPartnerIdSearchReturnsRelatedResults);
-
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 3, description = "Verfiy the results entering the values in lowercase if any of the fields have uppercase included in it")
-	public void textFieldSearchIsCaseInsensitive() {
-		navigateToPartnerListPage();
-
-		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
-
-		partnerAdminPage.clickOnFilterButton();
-		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId.toUpperCase());
-		partnerAdminPage.clickOnApplyFiltersBtn();
-
-		assertTrue(partnerAdminPage.isPartnerListLoaded(existingPartnerId),
-				GlobalConstants.isPartnerIdSearchCaseInsensitive);
-
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 4, description = "Verfiy the results when entered invalid values")
-	public void invalidValuesShowErrorOnlyAfterApplyNow() {
-		navigateToPartnerListPage();
-
-		partnerAdminPage.clickOnFilterButton();
-		partnerAdminPage.enterInvalidPartnerIdFilter(GlobalConstants.INVALID_DATA);
-		assertFalse(partnerAdminPage.isNoResultsFoundQuick(),
-				GlobalConstants.isNoResultsMessageAbsentBeforeApplyingInvalidFilter);
-
-		partnerAdminPage.clickOnApplyFiltersBtn();
-		assertTrue(partnerAdminPage.isNoResultsFoundsDisplayed(), GlobalConstants.isNoResultsFoundsDisplayed);
-
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 5, description = "Verfiy the Results on clicking Apply now after selected Dropdown/textfield search")
-	public void applyNowDisplaysFilteredResultsInTabularView() {
-		navigateToPartnerListPage();
-
-		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
-
-		partnerAdminPage.clickOnFilterButton();
-		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId);
-		partnerAdminPage.clickOnApplyFiltersBtn();
-
-		assertTrue(partnerAdminPage.isPartnerListLoaded(existingPartnerId),
-				GlobalConstants.isFilteredResultsDisplayedInTabularViewAfterApply);
-
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 6, description = "Verify the total number of filtered results is displayed properly")
-	public void filteredResultsCountDisplayedProperly() {
-		navigateToPartnerListPage();
-
-		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
-		int unfilteredCount = partnerAdminPage.getFilteredPartnersCountFromSubtitle();
-
-		partnerAdminPage.clickOnFilterButton();
-		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId);
-		partnerAdminPage.clickOnApplyFiltersBtn();
-		assertTrue(partnerAdminPage.waitForFilteredCountToChangeFrom(unfilteredCount),
-				GlobalConstants.isPartnerListLoaded);
-
-		assertEquals(partnerAdminPage.getFilteredPartnersCountFromSubtitle(),
-				partnerAdminPage.getPartnerIdColumnValues().size(),
-				GlobalConstants.isFilteredPartnersCountMatchesDisplayedRows);
-
-		partnerAdminPage.clickOnFilterResetButton();
-	}
-
-	@Test(priority = 7, description = "Verfiy the sort button functionality")
+	@Test(priority = 2, description = "Verfiy the sort button functionality")
 	public void sortButtonFunctionalityForPartnerIdColumn() {
 		navigateToPartnerListPage();
 
 		String firstRowBeforeSorting = partnerAdminPage.getFirstRowPartnerId();
 
+		// The list is paginated, so descending page 1 holds different records than ascending
+		// page 1 - each page is checked for being sorted in its own right, not against the other.
 		partnerAdminPage.clickOnPartnerIdAscendingIcon();
 		assertTrue(partnerAdminPage.waitForFirstRowPartnerIdToChangeFrom(firstRowBeforeSorting),
 				GlobalConstants.isPartnerListLoaded);
@@ -144,6 +63,97 @@ public class PartnerFilterTest extends BaseClass {
 		List<String> expectedDescendingOrder = new ArrayList<>(descendingOrder);
 		expectedDescendingOrder.sort(String.CASE_INSENSITIVE_ORDER.reversed());
 		assertEquals(descendingOrder, expectedDescendingOrder, GlobalConstants.isPartnerIdColumnSortedDescending);
+	}
+
+	private void verifyDropdownSelectionHasNoEffectBeforeApplyNow() {
+		LogUtil.step("Scenario: dropdown search results are not displayed without clicking Apply Now");
+		int baselineCount = partnerAdminPage.getPartnerRowCount();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.clickOnStatusFilter();
+		partnerAdminPage.clickOnDeActivatedStatusInFilters();
+
+		assertEquals(partnerAdminPage.getPartnerRowCount(), baselineCount,
+				GlobalConstants.isPartnerListUnchangedBeforeApplyingDropdownFilter);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	private void verifyPartialTextSearchReturnsRelatedResults() {
+		LogUtil.step("Scenario: entering a set of letters in a text field returns related results");
+		// Derived from the live list - partner IDs differ per environment, so nothing is hardcoded.
+		String partialPartnerId = partnerAdminPage.getFirstRowPartnerId().substring(0, PARTIAL_SEARCH_LENGTH);
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(partialPartnerId);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoaded(partialPartnerId),
+				GlobalConstants.isPartialPartnerIdSearchReturnsRelatedResults);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	private void verifyTextSearchIsCaseInsensitive() {
+		LogUtil.step("Scenario: text search results are not case sensitive");
+		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId.toUpperCase());
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoaded(existingPartnerId),
+				GlobalConstants.isPartnerIdSearchCaseInsensitive);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	private void verifyInvalidValuesShowErrorOnlyAfterApplyNow() {
+		LogUtil.step("Scenario: invalid values report no results only after Apply Now is clicked");
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterInvalidPartnerIdFilter(GlobalConstants.INVALID_DATA);
+		assertFalse(partnerAdminPage.isNoResultsFoundQuick(),
+				GlobalConstants.isNoResultsMessageAbsentBeforeApplyingInvalidFilter);
+
+		partnerAdminPage.clickOnApplyFiltersBtn();
+		assertTrue(partnerAdminPage.isNoResultsFoundsDisplayed(), GlobalConstants.isNoResultsFoundsDisplayed);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	private void verifyApplyNowDisplaysFilteredResultsInTabularView() {
+		LogUtil.step("Scenario: Apply Now displays the filtered results in the tabular view");
+		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoaded(existingPartnerId),
+				GlobalConstants.isFilteredResultsDisplayedInTabularViewAfterApply);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	private void verifyFilteredResultsCountDisplayedProperly() {
+		LogUtil.step("Scenario: the total number of filtered results is displayed properly");
+		// Filtering to a single partner keeps the total on one page, so the subtitle
+		// count and the rendered row count are directly comparable despite pagination.
+		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
+		int unfilteredCount = partnerAdminPage.getFilteredPartnersCountFromSubtitle();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+		assertTrue(partnerAdminPage.waitForFilteredCountToChangeFrom(unfilteredCount),
+				GlobalConstants.isPartnerListLoaded);
+
+		// Counting via the column reader, which waits for the rows to actually render.
+		assertEquals(partnerAdminPage.getFilteredPartnersCountFromSubtitle(),
+				partnerAdminPage.getPartnerIdColumnValues().size(),
+				GlobalConstants.isFilteredPartnersCountMatchesDisplayedRows);
+
+		partnerAdminPage.clickOnFilterResetButton();
 	}
 
 	private void navigateToPartnerListPage() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerFilterTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerFilterTest.java
@@ -125,7 +125,12 @@ public class PartnerFilterTest extends BaseClass {
 	public void sortButtonFunctionalityForPartnerIdColumn() {
 		navigateToPartnerListPage();
 
+		String firstRowBeforeSorting = partnerAdminPage.getFirstRowPartnerId();
+
 		partnerAdminPage.clickOnPartnerIdAscendingIcon();
+		assertTrue(partnerAdminPage.waitForFirstRowPartnerIdToChangeFrom(firstRowBeforeSorting),
+				GlobalConstants.isPartnerListLoaded);
+
 		List<String> ascendingOrder = partnerAdminPage.getPartnerIdColumnValues();
 		List<String> expectedAscendingOrder = new ArrayList<>(ascendingOrder);
 		expectedAscendingOrder.sort(String.CASE_INSENSITIVE_ORDER);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerFilterTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/PartnerFilterTest.java
@@ -1,0 +1,154 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.PartnerAdminPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+
+@Test(dependsOnGroups = { "PartnerDetailsTest" }, groups = { "PartnerFilterTest" })
+public class PartnerFilterTest extends BaseClass {
+
+	private static final int PARTIAL_SEARCH_LENGTH = 5;
+
+	private DashboardPage dashboardPage;
+	private PartnerAdminPage partnerAdminPage;
+
+	@Test(priority = 1, description = "Verify the Results for the dropdown search without clicking on apply now")
+	public void dropdownSearchResultsNotDisplayedWithoutApplyNow() {
+		navigateToPartnerListPage();
+
+		int baselineCount = partnerAdminPage.getPartnerRowCount();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.clickOnStatusFilter();
+		partnerAdminPage.clickOnDeActivatedStatusInFilters();
+
+		assertEquals(partnerAdminPage.getPartnerRowCount(), baselineCount,
+				GlobalConstants.isPartnerListUnchangedBeforeApplyingDropdownFilter);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 2, description = "Verify the results entering set of letters for any of the text field")
+	public void textFieldPartialSearchReturnsRelatedResults() {
+		navigateToPartnerListPage();
+
+		String partialPartnerId = partnerAdminPage.getFirstRowPartnerId().substring(0, PARTIAL_SEARCH_LENGTH);
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(partialPartnerId);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoaded(partialPartnerId),
+				GlobalConstants.isPartialPartnerIdSearchReturnsRelatedResults);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 3, description = "Verfiy the results entering the values in lowercase if any of the fields have uppercase included in it")
+	public void textFieldSearchIsCaseInsensitive() {
+		navigateToPartnerListPage();
+
+		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId.toUpperCase());
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoaded(existingPartnerId),
+				GlobalConstants.isPartnerIdSearchCaseInsensitive);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 4, description = "Verfiy the results when entered invalid values")
+	public void invalidValuesShowErrorOnlyAfterApplyNow() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterInvalidPartnerIdFilter(GlobalConstants.INVALID_DATA);
+		assertFalse(partnerAdminPage.isNoResultsFoundQuick(),
+				GlobalConstants.isNoResultsMessageAbsentBeforeApplyingInvalidFilter);
+
+		partnerAdminPage.clickOnApplyFiltersBtn();
+		assertTrue(partnerAdminPage.isNoResultsFoundsDisplayed(), GlobalConstants.isNoResultsFoundsDisplayed);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 5, description = "Verfiy the Results on clicking Apply now after selected Dropdown/textfield search")
+	public void applyNowDisplaysFilteredResultsInTabularView() {
+		navigateToPartnerListPage();
+
+		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		assertTrue(partnerAdminPage.isPartnerListLoaded(existingPartnerId),
+				GlobalConstants.isFilteredResultsDisplayedInTabularViewAfterApply);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 6, description = "Verify the total number of filtered results is displayed properly")
+	public void filteredResultsCountDisplayedProperly() {
+		navigateToPartnerListPage();
+
+		String existingPartnerId = partnerAdminPage.getFirstRowPartnerId();
+		int unfilteredCount = partnerAdminPage.getFilteredPartnersCountFromSubtitle();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.enterPartnerIdInFilter(existingPartnerId);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+		assertTrue(partnerAdminPage.waitForFilteredCountToChangeFrom(unfilteredCount),
+				GlobalConstants.isPartnerListLoaded);
+
+		assertEquals(partnerAdminPage.getFilteredPartnersCountFromSubtitle(),
+				partnerAdminPage.getPartnerIdColumnValues().size(),
+				GlobalConstants.isFilteredPartnersCountMatchesDisplayedRows);
+
+		partnerAdminPage.clickOnFilterResetButton();
+	}
+
+	@Test(priority = 7, description = "Verfiy the sort button functionality")
+	public void sortButtonFunctionalityForPartnerIdColumn() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnPartnerIdAscendingIcon();
+		List<String> ascendingOrder = partnerAdminPage.getPartnerIdColumnValues();
+		List<String> expectedAscendingOrder = new ArrayList<>(ascendingOrder);
+		expectedAscendingOrder.sort(String.CASE_INSENSITIVE_ORDER);
+		assertEquals(ascendingOrder, expectedAscendingOrder, GlobalConstants.isPartnerIdColumnSortedAscending);
+
+		partnerAdminPage.clickOnPartnerIdDescendingIcon();
+		assertTrue(partnerAdminPage.waitForFirstRowPartnerIdToChangeFrom(ascendingOrder.get(0)),
+				GlobalConstants.isPartnerListLoaded);
+
+		List<String> descendingOrder = partnerAdminPage.getPartnerIdColumnValues();
+		List<String> expectedDescendingOrder = new ArrayList<>(descendingOrder);
+		expectedDescendingOrder.sort(String.CASE_INSENSITIVE_ORDER.reversed());
+		assertEquals(descendingOrder, expectedDescendingOrder, GlobalConstants.isPartnerIdColumnSortedDescending);
+	}
+
+	private void navigateToPartnerListPage() {
+		dashboardPage = new DashboardPage(driver);
+		partnerAdminPage = new PartnerAdminPage(driver);
+
+		assertTrue(dashboardPage.isPartnersDisplayed(), GlobalConstants.isPartnersButtonDisplayed);
+		dashboardPage.clickOnPartners();
+		assertTrue(partnerAdminPage.isSubTitleListDisplayed(), GlobalConstants.isSubTitleListDisplayed);
+		assertTrue(partnerAdminPage.isPartnerListLoaded(), GlobalConstants.isPartnerListLoaded);
+	}
+
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -1663,4 +1663,36 @@ public class GlobalConstants {
 	public static final String isPolicyDataUploadDescriptionDisplayed = "Verify if policy data upload description displayed";
 	public static final String isStatusDisplayedForPolicyName = "Verify if status displayed for policy name";
 
+	// Partner Admin filter section
+	public static final String isPartnerListUnchangedBeforeApplyingDropdownFilter = "Verify partner list results remain unchanged until Apply Now is clicked for a dropdown filter selection";
+	public static final String isPartialPartnerIdSearchReturnsRelatedResults = "Verify a partial Partner ID search returns related results after clicking Apply Now";
+	public static final String isPartnerIdSearchCaseInsensitive = "Verify Partner ID search results are not case sensitive";
+	public static final String isNoResultsMessageAbsentBeforeApplyingInvalidFilter = "Verify the no results message is not displayed before Apply Now is clicked";
+	public static final String isFilteredResultsDisplayedInTabularViewAfterApply = "Verify filtered results are displayed in the tabular view after clicking Apply Now";
+	public static final String isFilteredPartnersCountMatchesDisplayedRows = "Verify the filtered count beside the List of Partners title matches the number of rows displayed";
+	public static final String isPartnerIdColumnSortedAscending = "Verify the partner list is sorted in ascending order of Partner ID";
+	public static final String isPartnerIdColumnSortedDescending = "Verify the partner list is sorted in descending order of Partner ID";
+
+	// List of Partners - email address sorting and filter updates
+	public static final String AUTHENTICATION_PARTNER = "Authentication Partner";
+	public static final String EMAIL_ADDRESS_COLUMN = "Email Address";
+	public static final String PARTNER_ID_COLUMN = "Partner ID";
+	public static final String EMAIL_ADDRESS_FILTER_PLACEHOLDER = "Search Full Email Address";
+	// Underscore is an allowed character, so a rejected value needs genuinely disallowed ones such as $ and %.
+	public static final String EMAIL_WITH_DISALLOWED_SPECIAL_CHARACTERS = "#@$$$%%";
+	public static final String NON_EXISTING_EMAIL = "nonexsit@gmail.com";
+	public static final String isEmailAddressColumnHeaderVisible = "Verify the Email Address column is visible in the List of Partners table header";
+	public static final String isSortIconLocatorValidForSortableColumn = "Verify a known sortable column exposes sort icons, confirming the sort icon lookup is valid";
+	public static final String isEmailAddressColumnNotSortable = "Verify no sorting icon is available in the Email Address column header";
+	public static final String isEmailAddressFilterPlaceholderCorrect = "Verify the email address filter textbox displays the expected placeholder text";
+	public static final String isExactEmailMatchReturningOnlyThatRecord = "Verify filtering by a full email address returns only the record with that exact email";
+	public static final String isPartialEmailReturningNoResults = "Verify filtering by a partial email address returns no results";
+	public static final String isNonExistingEmailReturningNoResults = "Verify filtering by a non-existing full email address returns no results";
+	public static final String isCombinedEmailAndPartnerTypeMismatchReturningNoResults = "Verify combining an email address with a non-matching Partner Type returns no results";
+	public static final String isEmailFilterCaseInsensitive = "Verify the email address filter is not case sensitive and still returns the matching record";
+	public static final String isInvalidCharacterErrorDisplayed = "Verify the invalid character message is displayed for an email containing disallowed special characters";
+	public static final String EMAIL_ADDRESS_FILTER_INFO_TOOLTIP = "Note: This filter performs an exact match. Please enter the full email address (e.g., user@example.com) to find results.";
+	public static final String isEmailAddressFilterInfoIconDisplayed = "Verify the info icon is displayed alongside the email address filter textbox";
+	public static final String isEmailAddressFilterInfoTooltipCorrect = "Verify the info icon tooltip displays the exact match guidance text";
+
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/TestRunner.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/TestRunner.java
@@ -80,6 +80,8 @@ public class TestRunner {
 			XmlClass authPartnerWithoutCertificateTest = new XmlClass(
 					"io.mosip.testrig.pmpuiv2.testcase.AuthPartnerWithoutCertificateTest");
 			XmlClass partnerDetailsTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PartnerDetailsTest");
+			XmlClass partnerFilterTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PartnerFilterTest");
+			XmlClass partnerEmailFilterTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PartnerEmailFilterTest");
 			XmlClass partnerDeactivateOptionTest = new XmlClass(
 					"io.mosip.testrig.pmpuiv2.testcase.PartnerDeactivateOptionTest");
 			XmlClass partnerDeactivatedPortalTest = new XmlClass(
@@ -178,6 +180,14 @@ public class TestRunner {
 					break;
 				case "PartnerDetailsTest":
 					addClassIfAbsent(classes, partnerAdminCreation, deactivatePartnerCreation, partnerDetailsTest);
+					break;
+				case "PartnerFilterTest":
+					addClassIfAbsent(classes, partnerAdminCreation, deactivatePartnerCreation, partnerDetailsTest,
+							partnerFilterTest);
+					break;
+				case "PartnerEmailFilterTest":
+					addClassIfAbsent(classes, partnerAdminCreation, deactivatePartnerCreation, partnerDetailsTest,
+							partnerEmailFilterTest);
 					break;
 				case "PartnerDeactivateOptionTest":
 					addClassIfAbsent(classes, partnerAdminCreation, deactivatePartnerCreation, partnerDetailsTest,

--- a/uitest-pmp-v2/src/main/resources/testngFile/testng.xml
+++ b/uitest-pmp-v2/src/main/resources/testngFile/testng.xml
@@ -43,6 +43,8 @@
 			<class name="io.mosip.testrig.pmpuiv2.testcase.AbisPartnerTest" />
 			<!--PARTNER VALIDATION & MANAGEMENT -->
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerDetailsTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerFilterTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerEmailFilterTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerDeactivateOptionTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerDeactivatedPortalTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.DeactivatePartner2Creation" />


### PR DESCRIPTION
## Description

Automates two stories in the PMS UI Testrig:

- **List of Partners: Filter section** — `PartnerFilterTest` (7 tests)
- **List of Partners: Updates in email address Sorting & Filter section** — `PartnerEmailFilterTest` (11 tests)

## Coverage

**PartnerFilterTest**
- Dropdown selection does not change results before Apply Now
- Partial text search returns related results
- Search is not case sensitive
- No-results message appears only after Apply Now
- Apply Now shows filtered results in the tabular view
- Filtered count beside the "List of Partners" title
- Ascending / descending sort icons

**PartnerEmailFilterTest**
- Email Address column is visible and has no sort icons
- Filter placeholder text
- Info icon and its tooltip text
- Exact-match filtering with a full email
- Partial and non-existing addresses return no results
- Email combined with a conflicting Partner Type returns no results
- Casing behaviour
- Disallowed special characters show the validation message

## Behaviour differing from the written acceptance criteria

Three expectations were corrected to match the QA environment (`qajava21`) after verifying against the live UI:

| Acceptance criteria | Actual behaviour |
|---|---|
| Placeholder `"Search email address"` | `"Search Full Email Address"` |
| Uppercase email returns no results | Filter is case **insensitive**, record is returned |
| `mosip_123@gmail.com` → "Special characters are not allowed." | Underscore is permitted; disallowed characters give `Invalid character. Allowed special characters are: @ # & ( ) \ - ' ? ! " : ; = _` |

## Notes

- Partner IDs and emails are read from the live list rather than hardcoded, so the tests are environment independent.
- The list is paginated, so sort order is asserted per page and the count check filters to a single record first.
- Adds stale-retry column readers, as the table re-renders after a filter is applied, and a `hoverOverElement` helper in `BasePage`.
- One case from the filter story — "Filter button should not appear when no partner is registered" — is **not** automated: earlier classes in the suite always create partners, so the empty-list precondition is unreachable.

## Testing

Full scoped run against `qajava21`: **23/23 passing, 0 failures** (18 new tests plus their 5 prerequisite classes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added partner-list filtering by Partner ID and email address.
  * Added ascending and descending Partner ID sorting.
  * Added filter placeholders, tooltips, result counts, and validation messages.
  * Added support for exact, partial, and case-insensitive email searches.

* **Bug Fixes**
  * Improved handling of invalid filter characters and empty search results.

* **Tests**
  * Added comprehensive coverage for partner filtering, sorting, email searches, and related UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->