### PR TITLE
MOSIP-45491 - Automate OIDC Client multilingual/additional-info fields and related PMS scenarios

### DIFF
--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/fw/util/PmpTestUtil.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/fw/util/PmpTestUtil.java
@@ -171,7 +171,23 @@ public class PmpTestUtil extends BaseTestCaseFunc {
 			return null;
 		}
 	}
-	
+
+	// A structurally valid public key in PEM format, used to prove the Public Key field rejects
+	// well-formed keys that simply aren't JWK, not just malformed text.
+	public static String generatePemPublicKey() {
+		try {
+			KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
+			SecureRandom secureRandom = new SecureRandom();
+			keyGenerator.initialize(2048, secureRandom);
+			final KeyPair keypair = keyGenerator.generateKeyPair();
+			String base64Key = java.util.Base64.getEncoder().encodeToString(keypair.getPublic().getEncoded());
+			return "-----BEGIN PUBLIC KEY-----\n" + base64Key + "\n-----END PUBLIC KEY-----";
+		} catch (NoSuchAlgorithmException e) {
+			logger.error(e.getMessage());
+			return null;
+		}
+	}
+
 	public static String getResourceFilePath(String folderName, String fileName) {
 		return Paths.get(TestRunner.getResourcePath(), folderName, fileName).toString();
 	}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/fw/util/PmpTestUtil.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/fw/util/PmpTestUtil.java
@@ -163,7 +163,7 @@ public class PmpTestUtil extends BaseTestCaseFunc {
 			keyGenerator.initialize(2048, secureRandom);
 			final KeyPair keypair = keyGenerator.generateKeyPair();
 			RSAKey jwk = new RSAKey.Builder((RSAPublicKey) keypair.getPublic()).keyID("RSAKeyID")
-					.keyUse(KeyUse.SIGNATURE).privateKey(keypair.getPrivate()).build();
+					.keyUse(KeyUse.SIGNATURE).build();
 
 			return jwk.toJSONString();
 		} catch (NoSuchAlgorithmException e) {
@@ -180,7 +180,8 @@ public class PmpTestUtil extends BaseTestCaseFunc {
 			SecureRandom secureRandom = new SecureRandom();
 			keyGenerator.initialize(2048, secureRandom);
 			final KeyPair keypair = keyGenerator.generateKeyPair();
-			String base64Key = java.util.Base64.getEncoder().encodeToString(keypair.getPublic().getEncoded());
+			String base64Key = java.util.Base64.getMimeEncoder(64, new byte[] { '\n' })
+					.encodeToString(keypair.getPublic().getEncoded());
 			return "-----BEGIN PUBLIC KEY-----\n" + base64Key + "\n-----END PUBLIC KEY-----";
 		} catch (NoSuchAlgorithmException e) {
 			logger.error(e.getMessage());

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/fw/util/PmpTestUtil.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/fw/util/PmpTestUtil.java
@@ -172,8 +172,6 @@ public class PmpTestUtil extends BaseTestCaseFunc {
 		}
 	}
 
-	// A structurally valid public key in PEM format, used to prove the Public Key field rejects
-	// well-formed keys that simply aren't JWK, not just malformed text.
 	public static String generatePemPublicKey() {
 		try {
 			KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/AuthPolicyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/AuthPolicyPage.java
@@ -1099,8 +1099,6 @@ public class AuthPolicyPage extends BasePage {
 		return isElementEnabled(saveAsDraftButton);
 	}
 
-	// The button stays disabled until the uploaded policy data has been parsed, so the
-	// clickable check has to wait for that rather than sample it the instant upload returns.
 	public boolean waitForSaveAsDraftButtonEnabled() {
 		try {
 			new WebDriverWait(driver, SAVE_AS_DRAFT_ENABLE_TIMEOUT).until(driver -> saveAsDraftButton.isEnabled());
@@ -1126,7 +1124,6 @@ public class AuthPolicyPage extends BasePage {
 		return isElementDisplayed(policyDraftInfoMessage);
 	}
 
-	// Whitespace collapsed so the assertion survives the message re-wrapping at a different width.
 	public String getDraftConfirmationDescriptionText() {
 		return getTextFromLocator(draftConfirmationDescription).replaceAll("\\s+", " ").trim();
 	}
@@ -1151,7 +1148,6 @@ public class AuthPolicyPage extends BasePage {
 		return getTextFromLocator(goBackButton).trim();
 	}
 
-	// Publish sits to the left of Go Back, so its left edge must be the smaller of the two.
 	public boolean isPublishButtonLeftOfGoBackButton() {
 		return getElementLeftEdge(draftConfirmationPublishButton) < getElementLeftEdge(goBackButton);
 	}
@@ -1160,8 +1156,6 @@ public class AuthPolicyPage extends BasePage {
 		clickOnElement(draftConfirmationPublishButton);
 	}
 
-	// Reports each button on the draft confirmation screen with its id, label and left edge,
-	// which is what the two-button / left-right placement expectation is checked against.
 	public String describeDraftConfirmationButtons() {
 		return (String) ((JavascriptExecutor) driver).executeScript(
 				"var out=[];" + "document.querySelectorAll('button').forEach(function(b){"

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/AuthPolicyPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/AuthPolicyPage.java
@@ -1,15 +1,21 @@
 package io.mosip.testrig.pmpuiv2.pages;
 
+import java.time.Duration;
+
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import io.mosip.testrig.pmpuiv2.fw.util.PmpTestUtil;
 
 public class AuthPolicyPage extends BasePage {
+
+	private static final Duration SAVE_AS_DRAFT_ENABLE_TIMEOUT = Duration.ofSeconds(20);
 
 	@FindBy(id = "create_auth_policy_btn")
 	private WebElement createAuthPolicyButton;
@@ -37,6 +43,9 @@ public class AuthPolicyPage extends BasePage {
 
 	@FindBy(id = "confirmation_go_back_btn")
 	private WebElement goBackButton;
+
+	@FindBy(id = "confirmation_custom_btn")
+	private WebElement draftConfirmationPublishButton;
 
 	@FindBy(id = "filter_btn")
 	private WebElement filterButton;
@@ -349,6 +358,12 @@ public class AuthPolicyPage extends BasePage {
 
 	@FindBy(xpath = "//p[contains(text(), 'This Authentication Policy is currently in draft mode')]")
 	private WebElement policyDraftInfoMessage;
+
+	@FindBy(id = "create_policy_confirmation_header")
+	private WebElement draftConfirmationHeader;
+
+	@FindBy(id = "create_policy_confirmation_description")
+	private WebElement draftConfirmationDescription;
 
 	@FindBy(id = "block_messsage_proceed")
 	private WebElement proceedButton;
@@ -1084,6 +1099,17 @@ public class AuthPolicyPage extends BasePage {
 		return isElementEnabled(saveAsDraftButton);
 	}
 
+	// The button stays disabled until the uploaded policy data has been parsed, so the
+	// clickable check has to wait for that rather than sample it the instant upload returns.
+	public boolean waitForSaveAsDraftButtonEnabled() {
+		try {
+			new WebDriverWait(driver, SAVE_AS_DRAFT_ENABLE_TIMEOUT).until(driver -> saveAsDraftButton.isEnabled());
+			return true;
+		} catch (TimeoutException e) {
+			return false;
+		}
+	}
+
 	public boolean isSaveAsDraftButtonDisabled() {
 		return isElementDisabled(saveAsDraftButton);
 	}
@@ -1098,6 +1124,51 @@ public class AuthPolicyPage extends BasePage {
 
 	public boolean isPolicyDraftInfoMessageDisplayed() {
 		return isElementDisplayed(policyDraftInfoMessage);
+	}
+
+	// Whitespace collapsed so the assertion survives the message re-wrapping at a different width.
+	public String getDraftConfirmationDescriptionText() {
+		return getTextFromLocator(draftConfirmationDescription).replaceAll("\\s+", " ").trim();
+	}
+
+	public String getDraftConfirmationHeaderText() {
+		return getTextFromLocator(draftConfirmationHeader).trim();
+	}
+
+	public boolean isDraftConfirmationPublishButtonDisplayed() {
+		return isElementDisplayed(draftConfirmationPublishButton);
+	}
+
+	public boolean isDraftConfirmationGoBackButtonDisplayed() {
+		return isElementDisplayed(goBackButton);
+	}
+
+	public String getDraftConfirmationPublishButtonText() {
+		return getTextFromLocator(draftConfirmationPublishButton).trim();
+	}
+
+	public String getDraftConfirmationGoBackButtonText() {
+		return getTextFromLocator(goBackButton).trim();
+	}
+
+	// Publish sits to the left of Go Back, so its left edge must be the smaller of the two.
+	public boolean isPublishButtonLeftOfGoBackButton() {
+		return getElementLeftEdge(draftConfirmationPublishButton) < getElementLeftEdge(goBackButton);
+	}
+
+	public void clickOnDraftConfirmationPublishButton() {
+		clickOnElement(draftConfirmationPublishButton);
+	}
+
+	// Reports each button on the draft confirmation screen with its id, label and left edge,
+	// which is what the two-button / left-right placement expectation is checked against.
+	public String describeDraftConfirmationButtons() {
+		return (String) ((JavascriptExecutor) driver).executeScript(
+				"var out=[];" + "document.querySelectorAll('button').forEach(function(b){"
+						+ "  var r=b.getBoundingClientRect();"
+						+ "  if(r.width>0 && r.height>0){"
+						+ "    out.push('[id='+(b.id||'-')+\" text='\"+b.innerText.trim()+\"' left=\"+Math.round(r.left)+' disabled='+b.disabled+']');"
+						+ "  }});" + "return out.join(' | ');");
 	}
 
 	public void clickOnProceedButton() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -404,6 +404,23 @@ public class BasePage {
 		}
 	}
 
+	protected boolean isElementSelected(WebElement element) {
+		LogUtil.verify("Checking if element is selected: ", element);
+		try {
+			WaitUtil.waitForVisibility(driver, element);
+			return element.isSelected();
+		} catch (StaleElementReferenceException e) {
+			LogUtil.step("Element became stale while checking selected state");
+			LogUtil.step("Page URL: " + driver.getCurrentUrl());
+			LogUtil.step("Page Title: " + driver.getTitle());
+			return false;
+		} catch (Exception e) {
+			LogUtil.error("isElementSelected failed: " + e.getClass().getSimpleName());
+			takeScreenshot();
+			return false;
+		}
+	}
+
 	protected boolean isElementEnabled(By locator) {
 		LogUtil.verify("Checking if element is enabled: ", locator);
 
@@ -600,6 +617,24 @@ public class BasePage {
 				element, tolerancePx));
 	}
 
+	// Left edge in viewport coordinates, for asserting the relative placement of two controls.
+	protected int getElementLeftEdge(WebElement element) {
+		WaitUtil.waitForVisibility(driver, element);
+		Number left = (Number) ((JavascriptExecutor) driver)
+				.executeScript("return arguments[0].getBoundingClientRect().left;", element);
+		return left.intValue();
+	}
+
+	// Compares the two bounding boxes directly, so a note that visually runs into a
+	// neighbouring field or button is caught even when neither covers the other's centre.
+	protected boolean doElementsOverlap(WebElement first, WebElement second) {
+		LogUtil.verify("Checking whether two elements overlap: ", first);
+		return Boolean.TRUE.equals(((JavascriptExecutor) driver).executeScript(
+				"var a=arguments[0].getBoundingClientRect();" + "var b=arguments[1].getBoundingClientRect();"
+						+ "return !(a.right<=b.left || a.left>=b.right || a.bottom<=b.top || a.top>=b.bottom);",
+				first, second));
+	}
+
 	// True when something else sits on top of the element's centre point, e.g. an overlay.
 	protected boolean isElementCoveredAtCentre(WebElement element) {
 		LogUtil.verify("Checking if element is covered by an overlay: ", element);
@@ -613,6 +648,16 @@ public class BasePage {
 	protected int getElementCount(By locator) {
 		LogUtil.verify("Counting elements for: ", locator);
 		return driver.findElements(locator).size();
+	}
+
+	// Exact text equality, so a search for 'Activated' can never match 'Deactivated'.
+	// Used by the status label checks, where that distinction is the whole point.
+	public int countElementsWithExactText(String text) {
+		return getElementCount(By.xpath("//*[normalize-space(text())='" + text + "']"));
+	}
+
+	public boolean isTextPresentOnPage(String text) {
+		return countElementsWithExactText(text) > 0;
 	}
 
 	public void scrollToEndPage() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -413,11 +413,11 @@ public class BasePage {
 			LogUtil.step("Element became stale while checking selected state");
 			LogUtil.step("Page URL: " + driver.getCurrentUrl());
 			LogUtil.step("Page Title: " + driver.getTitle());
-			return false;
+			throw e;
 		} catch (Exception e) {
 			LogUtil.error("isElementSelected failed: " + e.getClass().getSimpleName());
 			takeScreenshot();
-			return false;
+			throw new AssertionError("Unable to determine selected state", e);
 		}
 	}
 
@@ -618,11 +618,11 @@ public class BasePage {
 	}
 
 	// Left edge in viewport coordinates, for asserting the relative placement of two controls.
-	protected int getElementLeftEdge(WebElement element) {
+	protected double getElementLeftEdge(WebElement element) {
 		WaitUtil.waitForVisibility(driver, element);
 		Number left = (Number) ((JavascriptExecutor) driver)
 				.executeScript("return arguments[0].getBoundingClientRect().left;", element);
-		return left.intValue();
+		return left.doubleValue();
 	}
 
 	// Compares the two bounding boxes directly, so a note that visually runs into a
@@ -653,7 +653,19 @@ public class BasePage {
 	// Exact text equality, so a search for 'Activated' can never match 'Deactivated'.
 	// Used by the status label checks, where that distinction is the whole point.
 	public int countElementsWithExactText(String text) {
-		return getElementCount(By.xpath("//*[normalize-space(text())='" + text + "']"));
+		return getElementCount(By.xpath("//*[normalize-space(text())=" + toXpathLiteral(text) + "]"));
+	}
+
+	// XPath 1.0 has no escape character, so a value containing both quote types must be
+	// rebuilt with concat() - the only way to embed both without a literal delimiter clash.
+	private static String toXpathLiteral(String value) {
+		if (!value.contains("'")) {
+			return "'" + value + "'";
+		}
+		if (!value.contains("\"")) {
+			return "\"" + value + "\"";
+		}
+		return "concat('" + value.replace("'", "',\"'\",'") + "')";
 	}
 
 	public boolean isTextPresentOnPage(String text) {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/BasePage.java
@@ -617,7 +617,6 @@ public class BasePage {
 				element, tolerancePx));
 	}
 
-	// Left edge in viewport coordinates, for asserting the relative placement of two controls.
 	protected double getElementLeftEdge(WebElement element) {
 		WaitUtil.waitForVisibility(driver, element);
 		Number left = (Number) ((JavascriptExecutor) driver)
@@ -625,8 +624,6 @@ public class BasePage {
 		return left.doubleValue();
 	}
 
-	// Compares the two bounding boxes directly, so a note that visually runs into a
-	// neighbouring field or button is caught even when neither covers the other's centre.
 	protected boolean doElementsOverlap(WebElement first, WebElement second) {
 		LogUtil.verify("Checking whether two elements overlap: ", first);
 		return Boolean.TRUE.equals(((JavascriptExecutor) driver).executeScript(
@@ -650,14 +647,10 @@ public class BasePage {
 		return driver.findElements(locator).size();
 	}
 
-	// Exact text equality, so a search for 'Activated' can never match 'Deactivated'.
-	// Used by the status label checks, where that distinction is the whole point.
 	public int countElementsWithExactText(String text) {
 		return getElementCount(By.xpath("//*[normalize-space(text())=" + toXpathLiteral(text) + "]"));
 	}
 
-	// XPath 1.0 has no escape character, so a value containing both quote types must be
-	// rebuilt with concat() - the only way to embed both without a literal delimiter clash.
 	private static String toXpathLiteral(String value) {
 		if (!value.contains("'")) {
 			return "'" + value + "'";

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/MispServicesPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/MispServicesPage.java
@@ -341,15 +341,10 @@ public class MispServicesPage extends BasePage {
 		return isElementNotEditable(mispLicenseKeyImportantNote);
 	}
 
-	// Whitespace is collapsed so the assertion survives the note re-wrapping at a different width.
 	public String getMispLicenseKeyImportantNoteText() {
 		return getTextFromLocator(mispLicenseKeyImportantNote).replaceAll("\\s+", " ").trim();
 	}
 
-	// isElementNotEditable only rules out input/textarea tags, which a <p> note passes by
-	// construction. This actually types at the note directly (not whatever has focus) and
-	// reports whether the text survived unchanged - the behaviour the test case describes.
-	// Interaction failures are allowed to propagate rather than being read as "read-only".
 	public boolean isMispLicenseKeyImportantNoteUnchangedAfterTyping(String textToType) {
 		String before = getMispLicenseKeyImportantNoteText();
 		new Actions(driver).sendKeys(mispLicenseKeyImportantNote, textToType).perform();

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/MispServicesPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/MispServicesPage.java
@@ -347,16 +347,12 @@ public class MispServicesPage extends BasePage {
 	}
 
 	// isElementNotEditable only rules out input/textarea tags, which a <p> note passes by
-	// construction. This actually clicks the note and types at it, then reports whether the
-	// text survived unchanged - the behaviour the test case describes.
+	// construction. This actually types at the note directly (not whatever has focus) and
+	// reports whether the text survived unchanged - the behaviour the test case describes.
+	// Interaction failures are allowed to propagate rather than being read as "read-only".
 	public boolean isMispLicenseKeyImportantNoteUnchangedAfterTyping(String textToType) {
 		String before = getMispLicenseKeyImportantNoteText();
-		try {
-			clickOnElement(mispLicenseKeyImportantNote);
-			new Actions(driver).sendKeys(textToType).perform();
-		} catch (Exception notInteractable) {
-			LogUtil.step("Note rejected the interaction outright: " + notInteractable.getClass().getSimpleName());
-		}
+		new Actions(driver).sendKeys(mispLicenseKeyImportantNote, textToType).perform();
 		return before.equals(getMispLicenseKeyImportantNoteText());
 	}
 
@@ -374,6 +370,10 @@ public class MispServicesPage extends BasePage {
 
 	public boolean isImportantNoteOverlappingSubmitButton() {
 		return doElementsOverlap(mispLicenseKeyImportantNote, submitButton);
+	}
+
+	public boolean isLicenseKeyNameFieldDisplayed() {
+		return isElementDisplayed(licenseKeyNameTextbox);
 	}
 
 	public boolean isImportantNoteOverlappingLicenseKeyNameField() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/MispServicesPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/MispServicesPage.java
@@ -5,7 +5,10 @@ import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
+
+import io.mosip.testrig.pmpuiv2.utility.LogUtil;
 
 public class MispServicesPage extends BasePage {
 
@@ -336,6 +339,49 @@ public class MispServicesPage extends BasePage {
 
 	public boolean isMispLicenseKeyImportantNoteNotEditable() {
 		return isElementNotEditable(mispLicenseKeyImportantNote);
+	}
+
+	// Whitespace is collapsed so the assertion survives the note re-wrapping at a different width.
+	public String getMispLicenseKeyImportantNoteText() {
+		return getTextFromLocator(mispLicenseKeyImportantNote).replaceAll("\\s+", " ").trim();
+	}
+
+	// isElementNotEditable only rules out input/textarea tags, which a <p> note passes by
+	// construction. This actually clicks the note and types at it, then reports whether the
+	// text survived unchanged - the behaviour the test case describes.
+	public boolean isMispLicenseKeyImportantNoteUnchangedAfterTyping(String textToType) {
+		String before = getMispLicenseKeyImportantNoteText();
+		try {
+			clickOnElement(mispLicenseKeyImportantNote);
+			new Actions(driver).sendKeys(textToType).perform();
+		} catch (Exception notInteractable) {
+			LogUtil.step("Note rejected the interaction outright: " + notInteractable.getClass().getSimpleName());
+		}
+		return before.equals(getMispLicenseKeyImportantNoteText());
+	}
+
+	public boolean isMispLicenseKeyImportantNoteFocusable() {
+		return isElementFocusable(mispLicenseKeyImportantNote);
+	}
+
+	public boolean isMispLicenseKeyImportantNoteWithinViewport() {
+		return isElementWithinViewport(mispLicenseKeyImportantNote);
+	}
+
+	public boolean isMispLicenseKeyImportantNoteCovered() {
+		return isElementCoveredAtCentre(mispLicenseKeyImportantNote);
+	}
+
+	public boolean isImportantNoteOverlappingSubmitButton() {
+		return doElementsOverlap(mispLicenseKeyImportantNote, submitButton);
+	}
+
+	public boolean isImportantNoteOverlappingLicenseKeyNameField() {
+		return doElementsOverlap(mispLicenseKeyImportantNote, licenseKeyNameTextbox);
+	}
+
+	public boolean isImportantNoteOverlappingGuidenceNote() {
+		return doElementsOverlap(mispLicenseKeyImportantNote, mispLicenseKeyGuidence);
 	}
 
 	public boolean isPartnerTypePlaceholderDisplayed() {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/OidcClientPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/OidcClientPage.java
@@ -105,7 +105,7 @@ public class OidcClientPage extends BasePage {
 	@FindBy(xpath = "//h1[text()='Details Submitted Successfully!']")
 	private WebElement detailsSubmittedSuccessfully;
 
-	@FindBy(xpath = "//div[text()='Activated']")
+	@FindBy(xpath = "//div[text()='Active']")
 	private WebElement activatedText;
 
 	@FindBy(id = "confirmation_go_back_btn")
@@ -551,6 +551,107 @@ public class OidcClientPage extends BasePage {
 
 	@FindBy(xpath = "//p[contains(text(), 'Copied!')]")
 	private WebElement copied;
+
+	@FindBy(xpath = "//h3[text()='Primary Information']")
+	private WebElement primaryInformationSectionHeader;
+
+	@FindBy(xpath = "//h3[text()='Additional Information']")
+	private WebElement additionalInformationSectionHeader;
+
+	@FindBy(id = "forgot_password_banner_toggle")
+	private WebElement forgotPasswordBannerToggle;
+
+	@FindBy(id = "signup_banner_toggle")
+	private WebElement signUpBannerToggle;
+
+	@FindBy(id = "forgot_password_banner_info")
+	private WebElement forgotPasswordBannerInfoIcon;
+
+	@FindBy(id = "forgot_password_banner_info_info_description")
+	private WebElement forgotPasswordBannerInfoTooltip;
+
+	@FindBy(id = "consent_expiry_input")
+	private WebElement consentExpiryInput;
+
+	@FindBy(id = "user_info_response_type_dropdown_btn")
+	private WebElement userInfoResponseTypeDropdown;
+
+	@FindBy(id = "purpose_type_dropdown_btn")
+	private WebElement purposeTypeDropdown;
+
+	@FindBy(id = "create_oidc_grant_type_dropdown_btn")
+	private WebElement grantTypeDropdown;
+
+	// Clicking this same button adds the next language row - it relabels itself from
+	// "Add Client Name Language" to "+Add New" once the first row exists.
+	@FindBy(id = "add_client_name_lang_map_entry")
+	private WebElement addClientNameLanguageButton;
+
+	@FindBy(id = "client_name_lang_map_lang_1_dropdown_btn")
+	private WebElement clientNameLanguageDropdownRow1;
+
+	@FindBy(id = "client_name_lang_map_lang_2_dropdown_btn")
+	private WebElement clientNameLanguageDropdownRow2;
+
+	@FindBy(id = "client_name_lang_map_text_1")
+	private WebElement clientNameLanguageInputRow1;
+
+	@FindBy(id = "client_name_lang_map_text_2")
+	private WebElement clientNameLanguageInputRow2;
+
+	@FindBy(xpath = "//button[starts-with(@id,'client_name_lang_map_lang_1_option') and text()='English']")
+	private WebElement englishLanguageOption;
+
+	@FindBy(xpath = "//button[starts-with(@id,'client_name_lang_map_lang_1_option') and text()='Français']")
+	private WebElement frenchLanguageOption;
+
+	@FindBy(xpath = "//button[starts-with(@id,'client_name_lang_map_lang_1_option') and text()='العربية']")
+	private WebElement arabicLanguageOption;
+
+	@FindBy(xpath = "//button[starts-with(@id,'client_name_lang_map_lang_2_option') and text()='English']")
+	private WebElement englishLanguageOptionRow2;
+
+	@FindBy(xpath = "//button[starts-with(@id,'client_name_lang_map_lang_2_option') and text()='Français']")
+	private WebElement frenchLanguageOptionRow2;
+
+	@FindBy(id = "create_oidc_partner_id_label")
+	private WebElement partnerIdFieldLabel;
+
+	@FindBy(id = "create_oidc_client_partner_type_label")
+	private WebElement partnerTypeFieldLabel;
+
+	@FindBy(id = "create_oidc_client_partner_type_context")
+	private WebElement partnerTypeContext;
+
+	@FindBy(id = "create_oidc_client_policy_group_label")
+	private WebElement policyGroupFieldLabel;
+
+	@FindBy(id = "create_oidc_client_policy_group_context")
+	private WebElement policyGroupContext;
+
+	@FindBy(id = "create_oidc_policy_name_label")
+	private WebElement policyNameFieldLabel;
+
+	@FindBy(id = "create_oidc_client_name_label")
+	private WebElement oidcClientNameFieldLabel;
+
+	@FindBy(id = "create_oidc_client_public_key_label")
+	private WebElement publicKeyFieldLabel;
+
+	@FindBy(id = "create_oidc_logo_url_label")
+	private WebElement logoUriFieldLabel;
+
+	@FindBy(id = "create_oidc_redirect_url_label")
+	private WebElement redirectUriFieldLabel;
+
+	@FindBy(id = "create_oidc_grant_type_label")
+	private WebElement grantTypeFieldLabel;
+
+	@FindBy(xpath = "//tr[@id='oidc_client_list_item1']/td[4]")
+	private WebElement firstOidcClientRowName;
+
+	@FindBy(xpath = "//tr[@id='oidc_client_list_item1']/td[6]")
+	private WebElement firstOidcClientRowStatus;
 
 	public OidcClientPage(WebDriver driver) {
 		super(driver);
@@ -1460,6 +1561,170 @@ public class OidcClientPage extends BasePage {
 	public void selectDeactivateStatusInFilter() {
 		clickOnElement(statusFilter);
 		clickOnElement(deactivatedStatusInFilter);
+	}
+
+	public boolean isPrimaryInformationSectionDisplayed() {
+		return isElementDisplayed(primaryInformationSectionHeader);
+	}
+
+	public void clickOnPrimaryInformationSectionHeader() {
+		clickOnElement(primaryInformationSectionHeader);
+	}
+
+	public boolean isAdditionalInformationSectionDisplayed() {
+		return isElementDisplayed(additionalInformationSectionHeader);
+	}
+
+	public void clickOnAdditionalInformationSectionHeader() {
+		clickOnElement(additionalInformationSectionHeader);
+	}
+
+	public void clickOnForgotPasswordBannerToggle() {
+		clickOnElement(forgotPasswordBannerToggle);
+	}
+
+	public void clickOnSignUpBannerToggle() {
+		clickOnElement(signUpBannerToggle);
+	}
+
+	public void enterConsentExpiryDuration(String value) {
+		enter(consentExpiryInput, value);
+	}
+
+	public boolean isUserInfoResponseTypeDropdownDisplayed() {
+		return isElementDisplayed(userInfoResponseTypeDropdown);
+	}
+
+	public boolean isPurposeTypeDropdownDisplayed() {
+		return isElementDisplayed(purposeTypeDropdown);
+	}
+
+	public boolean isSubmitButtonEnabled() {
+		return isElementEnabled(submitButton);
+	}
+
+	public boolean isPartnerIdFieldLabelDisplayed() {
+		return isElementDisplayed(partnerIdFieldLabel);
+	}
+
+	public boolean isPartnerTypeFieldDisplayed() {
+		return isElementDisplayed(partnerTypeFieldLabel) && isElementDisplayed(partnerTypeContext);
+	}
+
+	public boolean isPolicyGroupFieldDisplayed() {
+		return isElementDisplayed(policyGroupFieldLabel) && isElementDisplayed(policyGroupContext);
+	}
+
+	public boolean isPolicyNameFieldLabelDisplayed() {
+		return isElementDisplayed(policyNameFieldLabel);
+	}
+
+	public boolean isOidcClientNameFieldLabelDisplayed() {
+		return isElementDisplayed(oidcClientNameFieldLabel);
+	}
+
+	public boolean isPublicKeyFieldLabelDisplayed() {
+		return isElementDisplayed(publicKeyFieldLabel);
+	}
+
+	public boolean isLogoUriFieldLabelDisplayed() {
+		return isElementDisplayed(logoUriFieldLabel);
+	}
+
+	public boolean isRedirectUriFieldLabelDisplayed() {
+		return isElementDisplayed(redirectUriFieldLabel);
+	}
+
+	public boolean isGrantTypeFieldLabelDisplayed() {
+		return isElementDisplayed(grantTypeFieldLabel);
+	}
+
+	public String getFirstOidcClientRowName() {
+		return getTextFromLocator(firstOidcClientRowName).trim();
+	}
+
+	public String getFirstOidcClientRowStatus() {
+		return getTextFromLocator(firstOidcClientRowStatus).trim();
+	}
+
+	public void clickOnGrantTypeDropdown() {
+		clickOnElement(grantTypeDropdown);
+	}
+
+	public void clickOnAddClientNameLanguageButton() {
+		clickOnElement(addClientNameLanguageButton);
+	}
+
+	public void clickOnClientNameLanguageDropdownRow1() {
+		clickOnElement(clientNameLanguageDropdownRow1);
+	}
+
+	public void clickOnClientNameLanguageDropdownRow2() {
+		clickOnElement(clientNameLanguageDropdownRow2);
+	}
+
+	public boolean isEnglishLanguageOptionDisplayed() {
+		return isElementDisplayed(englishLanguageOption);
+	}
+
+	public boolean isFrenchLanguageOptionDisplayed() {
+		return isElementDisplayed(frenchLanguageOption);
+	}
+
+	public boolean isArabicLanguageOptionDisplayed() {
+		return isElementDisplayed(arabicLanguageOption);
+	}
+
+	public void selectFrenchForClientNameLanguageRow2() {
+		clickOnElement(frenchLanguageOptionRow2);
+	}
+
+	public void enterClientNameForLanguageRow1(String value) {
+		enter(clientNameLanguageInputRow1, value);
+	}
+
+	public void enterClientNameForLanguageRow2(String value) {
+		enter(clientNameLanguageInputRow2, value);
+	}
+
+	public boolean isClientNameLanguageRow2Displayed() {
+		return isElementDisplayed(clientNameLanguageInputRow2);
+	}
+
+	public String getClientNameLanguageRow1SelectedText() {
+		return getTextFromLocator(clientNameLanguageDropdownRow1).trim();
+	}
+
+	public boolean isAddClientNameLanguageButtonDisplayed() {
+		return isElementDisplayed(addClientNameLanguageButton);
+	}
+
+	public String getClientNameLanguageRow1Placeholder() {
+		return getTextFromAttribute(clientNameLanguageInputRow1, "placeholder");
+	}
+
+	public boolean isEnglishLanguageOptionRow2Displayed() {
+		return isElementDisplayed(englishLanguageOptionRow2);
+	}
+
+	public boolean isFrenchLanguageOptionRow2Displayed() {
+		return isElementDisplayed(frenchLanguageOptionRow2);
+	}
+
+	public boolean isForgotPasswordBannerToggleOn() {
+		return isElementSelected(forgotPasswordBannerToggle);
+	}
+
+	public boolean isSignUpBannerToggleOn() {
+		return isElementSelected(signUpBannerToggle);
+	}
+
+	public void clickOnForgotPasswordBannerInfoIcon() {
+		clickOnElement(forgotPasswordBannerInfoIcon);
+	}
+
+	public String getForgotPasswordBannerInfoTooltipText() {
+		return getTextFromLocator(forgotPasswordBannerInfoTooltip).trim();
 	}
 
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/OidcClientPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/OidcClientPage.java
@@ -582,8 +582,6 @@ public class OidcClientPage extends BasePage {
 	@FindBy(id = "create_oidc_grant_type_dropdown_btn")
 	private WebElement grantTypeDropdown;
 
-	// Clicking this same button adds the next language row - it relabels itself from
-	// "Add Client Name Language" to "+Add New" once the first row exists.
 	@FindBy(id = "add_client_name_lang_map_entry")
 	private WebElement addClientNameLanguageButton;
 

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -631,6 +631,23 @@ public class PartnerAdminPage extends BasePage {
 		clickOnElement(emailAddressFilterInfoIcon);
 	}
 
+	// Option ids are positional, so the type is matched on its label instead.
+	public void selectPartnerTypeFilterOption(String partnerType) {
+		click(By.xpath("//button[starts-with(@id,'partner_type_filter_option') and normalize-space(text())='" + partnerType
+				+ "']"));
+	}
+
+	// The options only exist once the dropdown is open, so this waits rather than reading straight away.
+	public String getStatusFilterOptionText(int optionNumber) {
+		By option = By.id("status_filter_option" + optionNumber);
+		new WebDriverWait(driver, LIST_LOAD_TIMEOUT).until(ExpectedConditions.visibilityOfElementLocated(option));
+		return getCellTextWithStaleRetry(option);
+	}
+
+	public List<String> getStatusColumnValues() {
+		return getColumnValuesWithStaleRetry(By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[7]/div"));
+	}
+
 	// Row 1 is what the Action menu operates on; isDeactivatedPartnerRowDisplayed is pinned to row 2.
 	public boolean isFirstPartnerRowDisplayed() {
 		return isElementDisplayed(firstPartnerRow);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -877,6 +877,10 @@ public class PartnerAdminPage extends BasePage {
 		return getColumnValuesWithStaleRetry(By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[1]"));
 	}
 
+	public List<String> getPartnerTypeColumnValues() {
+		return getColumnValuesWithStaleRetry(By.xpath("//tr[starts-with(@id,'partner_list_item')]/td[2]"));
+	}
+
 	public boolean waitForFilteredCountToChangeFrom(int previousCount) {
 		try {
 			new WebDriverWait(driver, LIST_LOAD_TIMEOUT)

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/pages/PartnerAdminPage.java
@@ -631,13 +631,11 @@ public class PartnerAdminPage extends BasePage {
 		clickOnElement(emailAddressFilterInfoIcon);
 	}
 
-	// Option ids are positional, so the type is matched on its label instead.
 	public void selectPartnerTypeFilterOption(String partnerType) {
 		click(By.xpath("//button[starts-with(@id,'partner_type_filter_option') and normalize-space(text())='" + partnerType
 				+ "']"));
 	}
 
-	// The options only exist once the dropdown is open, so this waits rather than reading straight away.
 	public String getStatusFilterOptionText(int optionNumber) {
 		By option = By.id("status_filter_option" + optionNumber);
 		new WebDriverWait(driver, LIST_LOAD_TIMEOUT).until(ExpectedConditions.visibilityOfElementLocated(option));

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/DraftConfirmationScreenTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/DraftConfirmationScreenTest.java
@@ -23,7 +23,7 @@ public class DraftConfirmationScreenTest extends BaseClass {
 	private BasePage basePage;
 
 	@Test(priority = 1, description = "Verify Save as Draft button is clickable")
-	public void saveAsDraftButtonIsClickable() {
+	public void saveAsDraftButtonBecomesEnabled() {
 		fillNewAuthPolicyForm(uniquePolicyName("clickable"));
 
 		// The button starts disabled and only enables once the uploaded policy data is valid,

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/DraftConfirmationScreenTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/DraftConfirmationScreenTest.java
@@ -1,0 +1,118 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.pages.AuthPolicyPage;
+import io.mosip.testrig.pmpuiv2.pages.BasePage;
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.LoginPage;
+import io.mosip.testrig.pmpuiv2.pages.PoliciesPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+
+@Test(dependsOnGroups = { "PolicyGroupTest" }, groups = { "DraftConfirmationScreenTest" })
+public class DraftConfirmationScreenTest extends BaseClass {
+
+	private DashboardPage dashboardPage;
+	private PoliciesPage policiesPage;
+	private AuthPolicyPage authPolicyPage;
+	private LoginPage loginPage;
+	private BasePage basePage;
+
+	@Test(priority = 1, description = "Verify Save as Draft button is clickable")
+	public void saveAsDraftButtonIsClickable() {
+		fillNewAuthPolicyForm(uniquePolicyName("clickable"));
+
+		// The button starts disabled and only enables once the uploaded policy data is valid,
+		// so this waits for that transition rather than sampling it immediately.
+		assertTrue(authPolicyPage.waitForSaveAsDraftButtonEnabled(), GlobalConstants.isSaveAsDraftButtonEnabled);
+	}
+
+	@Test(priority = 2, description = "Verify draft confirmation message after clicking Save as Draft")
+	public void draftConfirmationMessageIsDisplayed() {
+		saveNewAuthPolicyAsDraft(uniquePolicyName("message"));
+
+		assertTrue(authPolicyPage.isPolicySavedAsDraftMessageDisplayed(),
+				GlobalConstants.isPolicySavedAsDraftMessageDisplayed);
+		assertEquals(authPolicyPage.getDraftConfirmationHeaderText(), GlobalConstants.DRAFT_CONFIRMATION_HEADER,
+				GlobalConstants.isDraftConfirmationHeaderDisplayed);
+		assertEquals(authPolicyPage.getDraftConfirmationDescriptionText(),
+				GlobalConstants.AUTH_POLICY_DRAFT_CONFIRMATION_MESSAGE,
+				GlobalConstants.isDraftConfirmationMessageCorrect);
+	}
+
+	@Test(priority = 3, description = "Verify confirmation screen provides two buttons after saving draft")
+	public void draftConfirmationScreenShowsPublishAndGoBackButtons() {
+		saveNewAuthPolicyAsDraft(uniquePolicyName("buttons"));
+
+		assertTrue(authPolicyPage.isDraftConfirmationPublishButtonDisplayed(),
+				GlobalConstants.isDraftConfirmationPublishButtonDisplayed);
+		assertTrue(authPolicyPage.isDraftConfirmationGoBackButtonDisplayed(),
+				GlobalConstants.isDraftConfirmationGoBackButtonDisplayed);
+
+		assertEquals(authPolicyPage.getDraftConfirmationPublishButtonText(), GlobalConstants.PUBLISH_BUTTON_LABEL,
+				GlobalConstants.isDraftConfirmationPublishButtonDisplayed);
+		assertEquals(authPolicyPage.getDraftConfirmationGoBackButtonText(), GlobalConstants.GO_BACK_BUTTON_LABEL,
+				GlobalConstants.isDraftConfirmationGoBackButtonDisplayed);
+
+		assertTrue(authPolicyPage.isPublishButtonLeftOfGoBackButton(), GlobalConstants.isPublishButtonOnLeftOfGoBack);
+	}
+
+	@Test(priority = 4, description = "Verify Go Back button functionality on draft confirmation screen")
+	public void goBackReturnsToListOfPolicies() {
+		saveNewAuthPolicyAsDraft(uniquePolicyName("goback"));
+
+		authPolicyPage.clickOnGoBackButton();
+		assertTrue(authPolicyPage.isListOfPoliciesPageDisplayed(), GlobalConstants.isRedirectedToPolicyListAfterGoBack);
+	}
+
+	@Test(priority = 5, description = "Verify Publish button functionality on draft confirmation screen")
+	public void publishFromDraftConfirmationStartsPublishFlow() {
+		saveNewAuthPolicyAsDraft(uniquePolicyName("publish"));
+
+		authPolicyPage.clickOnDraftConfirmationPublishButton();
+		assertTrue(authPolicyPage.isPublishPopupDisplayed(), GlobalConstants.isPublishInitiatedFromDraftConfirmation);
+		assertTrue(authPolicyPage.isPublishPopupInfoTextDisplayed(),
+				GlobalConstants.isPublishInitiatedFromDraftConfirmation);
+	}
+
+	// Policy names must be unique per run, and each test creates its own policy.
+	private String uniquePolicyName(String suffix) {
+		return GlobalConstants.DRAFT_CONFIRMATION_POLICY + suffix + data;
+	}
+
+	private void saveNewAuthPolicyAsDraft(String policyName) {
+		fillNewAuthPolicyForm(policyName);
+		assertTrue(authPolicyPage.waitForSaveAsDraftButtonEnabled(), GlobalConstants.isSaveAsDraftButtonEnabled);
+		authPolicyPage.clickOnSaveAsDraftButton();
+	}
+
+	private void fillNewAuthPolicyForm(String policyName) {
+		dashboardPage = new DashboardPage(driver);
+		basePage = new BasePage(driver);
+		policiesPage = new PoliciesPage(driver);
+		authPolicyPage = new AuthPolicyPage(driver);
+
+		loginAsPolicyAdmin();
+		dashboardPage.clickOnPolicyButton();
+		policiesPage.clickOnAuthPolicyTab();
+		authPolicyPage.clickOnCreateAuthPolicyButton();
+
+		// selectPolicyGroupDropdown opens the dropdown itself, so it must not be opened beforehand.
+		authPolicyPage.selectPolicyGroupDropdown(GlobalConstants.DEFAULT_POLICYGROUP);
+		authPolicyPage.enterPolicyName(policyName);
+		authPolicyPage.enterpolicyDescription(GlobalConstants.DRAFT_CONFIRMATION_POLICY_DESCRIPTION);
+		authPolicyPage.uploadPolicyData();
+		basePage.scrollToEndPage();
+	}
+
+	private void loginAsPolicyAdmin() {
+		dashboardPage.clickOnProfileDropdown();
+		loginPage = dashboardPage.clickOnLogoutButton();
+		loginPage.login(GlobalConstants.POLICIES_ADMIN, GlobalConstants.PARTNER_PASSWORD);
+	}
+
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/DraftConfirmationScreenTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/DraftConfirmationScreenTest.java
@@ -26,8 +26,6 @@ public class DraftConfirmationScreenTest extends BaseClass {
 	public void saveAsDraftButtonBecomesEnabled() {
 		fillNewAuthPolicyForm(uniquePolicyName("clickable"));
 
-		// The button starts disabled and only enables once the uploaded policy data is valid,
-		// so this waits for that transition rather than sampling it immediately.
 		assertTrue(authPolicyPage.waitForSaveAsDraftButtonEnabled(), GlobalConstants.isSaveAsDraftButtonEnabled);
 	}
 
@@ -79,7 +77,6 @@ public class DraftConfirmationScreenTest extends BaseClass {
 				GlobalConstants.isPublishInitiatedFromDraftConfirmation);
 	}
 
-	// Policy names must be unique per run, and each test creates its own policy.
 	private String uniquePolicyName(String suffix) {
 		return GlobalConstants.DRAFT_CONFIRMATION_POLICY + suffix + data;
 	}
@@ -101,7 +98,6 @@ public class DraftConfirmationScreenTest extends BaseClass {
 		policiesPage.clickOnAuthPolicyTab();
 		authPolicyPage.clickOnCreateAuthPolicyButton();
 
-		// selectPolicyGroupDropdown opens the dropdown itself, so it must not be opened beforehand.
 		authPolicyPage.selectPolicyGroupDropdown(GlobalConstants.DEFAULT_POLICYGROUP);
 		authPolicyPage.enterPolicyName(policyName);
 		authPolicyPage.enterpolicyDescription(GlobalConstants.DRAFT_CONFIRMATION_POLICY_DESCRIPTION);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/MispServicesTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/MispServicesTest.java
@@ -9,6 +9,7 @@ import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test(dependsOnGroups = { "MispPolicyTest" }, groups = { "MispServicesTest" })
@@ -141,6 +142,63 @@ public class MispServicesTest extends BaseClass {
                 GlobalConstants.isGenerateLicenseKeyErrorMessageDisplayed);
         mispServicesPage.clickOnClearFormButton();
 
+    }
+
+    @Test(priority = 2, description = "Verify Note Display on License Key Generation Screen")
+    public void importantNoteDisplayedWithExpectedTextOnGenerateScreen() {
+        openGenerateMispLicenseKeyScreen();
+
+        assertTrue(mispServicesPage.isMispLicenseKeyImportantNoteDisplayed(),
+                GlobalConstants.isMispLicenseKeyImportantNoteDisplayed);
+        assertEquals(mispServicesPage.getMispLicenseKeyImportantNoteText(),
+                GlobalConstants.MISP_LICENSE_KEY_IMPORTANT_NOTE, GlobalConstants.isImportantNoteTextCorrect);
+    }
+
+    @Test(priority = 3, description = "Verify Important Note is Read-Only")
+    public void importantNoteIsReadOnlyOnGenerateScreen() {
+        openGenerateMispLicenseKeyScreen();
+
+        assertTrue(mispServicesPage.isMispLicenseKeyImportantNoteNotEditable(),
+                GlobalConstants.isMispLicenseKeyImportantNoteNotEditable);
+        assertFalse(mispServicesPage.isMispLicenseKeyImportantNoteFocusable(),
+                GlobalConstants.isImportantNoteNotFocusable);
+        assertTrue(
+                mispServicesPage
+                        .isMispLicenseKeyImportantNoteUnchangedAfterTyping(GlobalConstants.IMPORTANT_NOTE_EDIT_ATTEMPT),
+                GlobalConstants.isImportantNoteReadOnly);
+    }
+
+    @Test(priority = 4, description = "Verify Note Does Not Interfere with Form Fields or Buttons")
+    public void importantNoteDoesNotInterfereWithFormFieldsOnGenerateScreen() {
+        openGenerateMispLicenseKeyScreen();
+
+        assertTrue(mispServicesPage.isMispLicenseKeyImportantNoteWithinViewport(),
+                GlobalConstants.isImportantNoteFullyVisible);
+        assertFalse(mispServicesPage.isMispLicenseKeyImportantNoteCovered(), GlobalConstants.isImportantNoteNotCovered);
+
+        assertFalse(mispServicesPage.isImportantNoteOverlappingSubmitButton(),
+                GlobalConstants.isImportantNoteNotOverlappingFormFields);
+        assertFalse(mispServicesPage.isImportantNoteOverlappingLicenseKeyNameField(),
+                GlobalConstants.isImportantNoteNotOverlappingFormFields);
+        assertFalse(mispServicesPage.isImportantNoteOverlappingGuidenceNote(),
+                GlobalConstants.isImportantNoteNotOverlappingFormFields);
+
+        // The form must still work with the note on screen.
+        assertTrue(mispServicesPage.isSubmitButtonDisplayed(), GlobalConstants.isSubmitButtonDisplayed);
+        assertTrue(mispServicesPage.isCancelButtonDisplayed(), GlobalConstants.isCancelButtonDisplayed);
+        assertTrue(mispServicesPage.isClearFormButtonDisplayed(), GlobalConstants.isClearFormButtonDisplayed);
+    }
+
+    private void openGenerateMispLicenseKeyScreen() {
+        dashboardPage = new DashboardPage(driver);
+        mispServicesPage = new MispServicesPage(driver);
+
+        dashboardPage.clickOnMispServices();
+        assertTrue(mispServicesPage.isGenerateMispLicenceKeyButtonDisplayed(),
+                GlobalConstants.isGenerateMispLicenceKeyButtonDisplayed);
+        mispServicesPage.clickOnGenerateMispLicenceKeyButton();
+        assertTrue(mispServicesPage.isGenerateMispLicenceKeyPageDisplayed(),
+                GlobalConstants.isGenerateMispLicenceKeyPageDisplayed);
     }
 
     private void createMispLicenseKey(String partnerIdValue, String policyName, String licenseKeyName) {

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/MispServicesTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/MispServicesTest.java
@@ -188,7 +188,6 @@ public class MispServicesTest extends BaseClass {
         assertFalse(mispServicesPage.isImportantNoteOverlappingGuidenceNote(),
                 GlobalConstants.isImportantNoteNotOverlappingFormFields);
 
-        // The form must still work with the note on screen.
         assertTrue(mispServicesPage.isSubmitButtonDisplayed(), GlobalConstants.isSubmitButtonDisplayed);
         assertTrue(mispServicesPage.isCancelButtonDisplayed(), GlobalConstants.isCancelButtonDisplayed);
         assertTrue(mispServicesPage.isClearFormButtonDisplayed(), GlobalConstants.isClearFormButtonDisplayed);

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/MispServicesTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/MispServicesTest.java
@@ -176,6 +176,11 @@ public class MispServicesTest extends BaseClass {
                 GlobalConstants.isImportantNoteFullyVisible);
         assertFalse(mispServicesPage.isMispLicenseKeyImportantNoteCovered(), GlobalConstants.isImportantNoteNotCovered);
 
+        assertTrue(mispServicesPage.isLicenseKeyNameFieldDisplayed(),
+                GlobalConstants.isMispLicenseKeyNamePlaceholderDisplayed);
+        assertTrue(mispServicesPage.isMispLicenseKeyGuidenceNoteDisplayed(),
+                GlobalConstants.isMispLicenseKeyGuidenceNoteDisplayed);
+
         assertFalse(mispServicesPage.isImportantNoteOverlappingSubmitButton(),
                 GlobalConstants.isImportantNoteNotOverlappingFormFields);
         assertFalse(mispServicesPage.isImportantNoteOverlappingLicenseKeyNameField(),

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/OidcClientMultilingualFieldsTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/OidcClientMultilingualFieldsTest.java
@@ -1,0 +1,217 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.fw.util.PmpTestUtil;
+import io.mosip.testrig.pmpuiv2.kernel.util.ConfigManager;
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.LoginPage;
+import io.mosip.testrig.pmpuiv2.pages.OidcClientPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+
+// Test methods here are grouped by which part of the Create OIDC Client form they exercise, so
+// each method opens the form once and runs every related scenario against that single session
+// rather than relaunching the browser per scenario. See individual method comments for which
+// manual test case each assertion maps to.
+@Test(dependsOnGroups = { "PolicyCreationForAuthPartner" }, groups = { "OidcClientMultilingualFieldsTest" })
+public class OidcClientMultilingualFieldsTest extends BaseClass {
+
+	private DashboardPage dashboardPage;
+	private LoginPage loginPage;
+
+	@Test(priority = 1, description = "Verify login and Authentication Services card on the PMS home screen")
+	public void loginAndDashboardChecks() {
+		loginAsAuthPartner();
+
+		assertTrue(dashboardPage.isWelcomeMessageDisplayed(), GlobalConstants.isWelcomeMessageDisplayed);
+		assertTrue(dashboardPage.isAuthenticationServicesTitleDisplayed(),
+				GlobalConstants.isAuthenticationServicesDisplayed);
+	}
+
+	// The manual test case refers to the first section as "Mandatory Information"; the live UI labels it
+	// "Primary Information".
+	@Test(priority = 2, description = "Verify Create OIDC Client form layout - sections, field labels, and Grant Type")
+	public void createFormLayoutChecks() {
+		OidcClientPage oidcClientPage = openCreateOidcClientForm();
+
+		assertTrue(oidcClientPage.isPrimaryInformationSectionDisplayed(),
+				GlobalConstants.isPrimaryInformationSectionDisplayed);
+		assertTrue(oidcClientPage.isAdditionalInformationSectionDisplayed(),
+				GlobalConstants.isAdditionalInformationSectionDisplayed);
+
+		oidcClientPage.clickOnPrimaryInformationSectionHeader();
+		assertFalse(oidcClientPage.isPartnerIdDropdownDisplayed(),
+				GlobalConstants.isPrimaryInformationSectionCollapsible);
+		oidcClientPage.clickOnPrimaryInformationSectionHeader();
+		assertTrue(oidcClientPage.isPartnerIdDropdownDisplayed(),
+				GlobalConstants.isPrimaryInformationSectionCollapsible);
+
+		oidcClientPage.clickOnAdditionalInformationSectionHeader();
+		assertTrue(oidcClientPage.isUserInfoResponseTypeDropdownDisplayed(),
+				GlobalConstants.isAdditionalInformationSectionCollapsible);
+		oidcClientPage.clickOnAdditionalInformationSectionHeader();
+		assertFalse(oidcClientPage.isUserInfoResponseTypeDropdownDisplayed(),
+				GlobalConstants.isAdditionalInformationSectionCollapsible);
+
+		assertTrue(oidcClientPage.isPartnerIdFieldLabelDisplayed(), GlobalConstants.isPartnerIdFieldLabelDisplayed);
+		assertTrue(oidcClientPage.isPartnerTypeFieldDisplayed(), GlobalConstants.isPartnerTypeFieldDisplayed);
+		assertTrue(oidcClientPage.isPolicyGroupFieldDisplayed(), GlobalConstants.isPolicyGroupFieldDisplayed);
+		assertTrue(oidcClientPage.isPolicyNameFieldLabelDisplayed(), GlobalConstants.isPolicyNameFieldLabelDisplayed);
+		assertTrue(oidcClientPage.isOidcClientNameFieldLabelDisplayed(),
+				GlobalConstants.isOidcClientNameFieldLabelDisplayed);
+		assertTrue(oidcClientPage.isPublicKeyFieldLabelDisplayed(), GlobalConstants.isPublicKeyFieldLabelDisplayed);
+		assertTrue(oidcClientPage.isLogoUriFieldLabelDisplayed(), GlobalConstants.isLogoUriFieldLabelDisplayed);
+		assertTrue(oidcClientPage.isRedirectUriFieldLabelDisplayed(), GlobalConstants.isRedirectUriFieldLabelDisplayed);
+		assertTrue(oidcClientPage.isGrantTypeFieldLabelDisplayed(), GlobalConstants.isGrantTypeFieldLabelDisplayed);
+
+		assertTrue(oidcClientPage.isAuthorizationCodeTextDisplayed(),
+				GlobalConstants.isGrantTypePreSelectedAsAuthorizationCode);
+		oidcClientPage.clickOnGrantTypeDropdown();
+		assertTrue(oidcClientPage.isAuthorizationCodeTextDisplayed(), GlobalConstants.isGrantTypeNonEditable);
+	}
+
+	// The manual test case says the language dropdown should contain "Default"; the live UI has no such
+	// option (only English/Français/العربية), but does pre-select English as the default value for a new
+	// row - that reinterpretation is what's verified here. The placeholder-text scenario likewise expects
+	// different wording than what the live UI actually shows; the real text is asserted instead.
+	@Test(priority = 3, description = "Verify OIDC Client Name multilingual section - Add New, language options, defaults")
+	public void multilingualSectionChecks() {
+		OidcClientPage oidcClientPage = openCreateOidcClientForm();
+
+		assertTrue(oidcClientPage.isAddClientNameLanguageButtonDisplayed(),
+				GlobalConstants.isAddNewLanguageButtonVisibleAndClickable);
+		oidcClientPage.clickOnAddClientNameLanguageButton();
+
+		assertTrue(oidcClientPage.getClientNameLanguageRow1SelectedText().equalsIgnoreCase("English"),
+				GlobalConstants.isLanguageDropdownDefaultsToEnglish);
+		assertTrue(
+				oidcClientPage.getClientNameLanguageRow1Placeholder()
+						.equals("Please enter the OIDC client name in English"),
+				GlobalConstants.isClientNameLanguageRow1PlaceholderCorrect);
+
+		oidcClientPage.clickOnClientNameLanguageDropdownRow1();
+		assertTrue(oidcClientPage.isEnglishLanguageOptionDisplayed(), GlobalConstants.isConfiguredLanguageCodesInDropdown);
+		assertTrue(oidcClientPage.isFrenchLanguageOptionDisplayed(), GlobalConstants.isConfiguredLanguageCodesInDropdown);
+		assertTrue(oidcClientPage.isArabicLanguageOptionDisplayed(), GlobalConstants.isConfiguredLanguageCodesInDropdown);
+
+		oidcClientPage.clickOnAddClientNameLanguageButton();
+		oidcClientPage.clickOnClientNameLanguageDropdownRow2();
+		assertFalse(oidcClientPage.isEnglishLanguageOptionRow2Displayed(),
+				GlobalConstants.isRow2ExcludesAlreadySelectedLanguage);
+		assertTrue(oidcClientPage.isFrenchLanguageOptionRow2Displayed(),
+				GlobalConstants.isRow2ExcludesAlreadySelectedLanguage);
+	}
+
+	@Test(priority = 4, description = "Verify Forgot Password / SignUp Banner toggle defaults and info tooltip text")
+	public void additionalInfoChecks() {
+		OidcClientPage oidcClientPage = openCreateOidcClientForm();
+
+		oidcClientPage.clickOnAdditionalInformationSectionHeader();
+
+		assertTrue(oidcClientPage.isForgotPasswordBannerToggleOn(), GlobalConstants.isForgotPasswordBannerToggleOnByDefault);
+		assertTrue(oidcClientPage.isSignUpBannerToggleOn(), GlobalConstants.isSignUpBannerToggleOnByDefault);
+
+		oidcClientPage.clickOnForgotPasswordBannerInfoIcon();
+		assertTrue(
+				oidcClientPage.getForgotPasswordBannerInfoTooltipText().equals(
+						"Enable this option to display 'Forgot Password' link on the eSignet authentication screen."),
+				GlobalConstants.isForgotPasswordBannerInfoTooltipCorrect);
+	}
+
+	// Fields are filled in one at a time so each still-incomplete state can confirm Submit stays disabled;
+	// this covers Partner ID / Policy Name / Public Key / Logo URI / Redirect URI mandatory checks in one
+	// pass, plus the Public Key JWK-format rejection along the way.
+	@Test(priority = 5, description = "Verify Submit button stays disabled until every mandatory field is filled")
+	public void submitValidationChecks() {
+		OidcClientPage oidcClientPage = openCreateOidcClientForm();
+
+		assertFalse(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitDisabledWhenPartnerIdEmpty);
+
+		oidcClientPage.selectPartnerIdDropdown();
+		assertFalse(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitDisabledWhenPolicyNameEmpty);
+
+		oidcClientPage.selectPolicyNameDropdown(GlobalConstants.DEFAULT_POLICY);
+		oidcClientPage.enterNameOidcTextBox(GlobalConstants.DEFAULT_POLICY + BaseClass.data);
+		assertFalse(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitDisabledWhenPublicKeyEmpty);
+
+		oidcClientPage.enterPublicKeyTextBox(PmpTestUtil.generatePemPublicKey());
+		assertTrue(oidcClientPage.isPublicKeyFormatErrorDisplayed(), GlobalConstants.isPublicKeyRejectedForNonJwkFormat);
+
+		oidcClientPage.enterPublicKeyTextBox(PmpTestUtil.generateJWKPublicKey());
+		assertFalse(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitDisabledWhenLogoUriEmpty);
+
+		oidcClientPage.enterLogoUrTextBox(ConfigManager.getLogouri());
+		assertFalse(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitDisabledWhenRedirectUriEmpty);
+
+		oidcClientPage.enterRedirectUriTextBox(ConfigManager.getRedirectUri());
+		assertTrue(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitButtonEnabledAfterFillingForm);
+	}
+
+	// Fills every mandatory and optional field (including a second multilingual name row, first left blank
+	// to confirm Submit disables, then completed), submits, and verifies the resulting confirmation and
+	// list state.
+	@Test(priority = 6, description = "Verify partner can create an OIDC Client with required and optional details")
+	public void fillAndSubmitFlow() {
+		OidcClientPage oidcClientPage = openCreateOidcClientForm();
+
+		String oidcClientName = GlobalConstants.DEFAULT_POLICY + BaseClass.data;
+		oidcClientPage.selectPartnerIdDropdown();
+		oidcClientPage.selectPolicyNameDropdown(GlobalConstants.DEFAULT_POLICY);
+		oidcClientPage.enterNameOidcTextBox(oidcClientName);
+		oidcClientPage.enterPublicKeyTextBox(PmpTestUtil.generateJWKPublicKey());
+		oidcClientPage.enterLogoUrTextBox(ConfigManager.getLogouri());
+		oidcClientPage.enterRedirectUriTextBox(ConfigManager.getRedirectUri());
+
+		oidcClientPage.clickOnAddClientNameLanguageButton();
+		oidcClientPage.enterClientNameForLanguageRow1(oidcClientName);
+
+		oidcClientPage.clickOnAddClientNameLanguageButton();
+		oidcClientPage.clickOnClientNameLanguageDropdownRow2();
+		oidcClientPage.selectFrenchForClientNameLanguageRow2();
+		assertFalse(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitDisabledWhenLanguageRowTextBlank);
+
+		oidcClientPage.enterClientNameForLanguageRow2(oidcClientName);
+		assertTrue(oidcClientPage.isClientNameLanguageRow2Displayed(), GlobalConstants.isMultipleLanguageRowsSupported);
+
+		oidcClientPage.clickOnAdditionalInformationSectionHeader();
+		oidcClientPage.clickOnForgotPasswordBannerToggle();
+		oidcClientPage.clickOnSignUpBannerToggle();
+		oidcClientPage.enterConsentExpiryDuration("15");
+
+		assertTrue(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitButtonEnabledAfterFillingForm);
+		oidcClientPage.clickOnSubmitButton();
+
+		assertTrue(oidcClientPage.isOidcSubmittedSuccessfullyDisplayed(),
+				GlobalConstants.isOidcSubmittedSuccessfullyDisplayed);
+		oidcClientPage.clickConfirmationGoBackButton();
+
+		assertTrue(oidcClientPage.isOidcClientTabDisplayed(), GlobalConstants.isRedirectedToOidcClientListAfterSubmit);
+		assertTrue(oidcClientPage.getFirstOidcClientRowName().contains(oidcClientName),
+				GlobalConstants.isNewOidcClientNameAtTopOfList);
+		assertTrue(oidcClientPage.getFirstOidcClientRowStatus().equalsIgnoreCase(GlobalConstants.PARTNER_STATUS_ACTIVE),
+				GlobalConstants.isNewOidcClientStatusActive);
+	}
+
+	private OidcClientPage openCreateOidcClientForm() {
+		loginAsAuthPartner();
+
+		OidcClientPage oidcClientPage = dashboardPage.clickOnAuthenticationServicesTitle();
+		assertTrue(oidcClientPage.isOidcClientTabDisplayed(), GlobalConstants.isOidcClientTabDisplayed);
+		oidcClientPage.clickOnCreateOidcClientButton();
+		return oidcClientPage;
+	}
+
+	private void loginAsAuthPartner() {
+		dashboardPage = new DashboardPage(driver);
+		dashboardPage.clickOnProfileDropdown();
+		loginPage = dashboardPage.clickOnLogoutButton();
+		loginPage.enterUserName(GlobalConstants.AUTH_PARTNER_ID);
+		loginPage.enterPassword(GlobalConstants.PARTNER_PASSWORD);
+		loginPage.clickOnLoginButton();
+	}
+
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/OidcClientMultilingualFieldsTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/OidcClientMultilingualFieldsTest.java
@@ -13,10 +13,6 @@ import io.mosip.testrig.pmpuiv2.pages.OidcClientPage;
 import io.mosip.testrig.pmpuiv2.utility.BaseClass;
 import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
 
-// Test methods here are grouped by which part of the Create OIDC Client form they exercise, so
-// each method opens the form once and runs every related scenario against that single session
-// rather than relaunching the browser per scenario. See individual method comments for which
-// manual test case each assertion maps to.
 @Test(dependsOnGroups = { "PolicyCreationForAuthPartner" }, groups = { "OidcClientMultilingualFieldsTest" })
 public class OidcClientMultilingualFieldsTest extends BaseClass {
 
@@ -32,9 +28,7 @@ public class OidcClientMultilingualFieldsTest extends BaseClass {
 				GlobalConstants.isAuthenticationServicesDisplayed);
 	}
 
-	// The manual test case refers to the first section as "Mandatory Information"; the live UI labels it
-	// "Primary Information".
-	@Test(priority = 2, description = "Verify Create OIDC Client form layout - sections, field labels, and Grant Type")
+	@Test(priority = 2, description = "Verify Create OIDC Client form layout - sections, field labels, and Grant Type", dependsOnMethods = "loginAndDashboardChecks")
 	public void createFormLayoutChecks() {
 		OidcClientPage oidcClientPage = openCreateOidcClientForm();
 
@@ -74,11 +68,7 @@ public class OidcClientMultilingualFieldsTest extends BaseClass {
 		assertTrue(oidcClientPage.isAuthorizationCodeTextDisplayed(), GlobalConstants.isGrantTypeNonEditable);
 	}
 
-	// The manual test case says the language dropdown should contain "Default"; the live UI has no such
-	// option (only English/Français/العربية), but does pre-select English as the default value for a new
-	// row - that reinterpretation is what's verified here. The placeholder-text scenario likewise expects
-	// different wording than what the live UI actually shows; the real text is asserted instead.
-	@Test(priority = 3, description = "Verify OIDC Client Name multilingual section - Add New, language options, defaults")
+	@Test(priority = 3, description = "Verify OIDC Client Name multilingual section - Add New, language options, defaults", dependsOnMethods = "createFormLayoutChecks")
 	public void multilingualSectionChecks() {
 		OidcClientPage oidcClientPage = openCreateOidcClientForm();
 
@@ -97,6 +87,7 @@ public class OidcClientMultilingualFieldsTest extends BaseClass {
 		assertTrue(oidcClientPage.isEnglishLanguageOptionDisplayed(), GlobalConstants.isConfiguredLanguageCodesInDropdown);
 		assertTrue(oidcClientPage.isFrenchLanguageOptionDisplayed(), GlobalConstants.isConfiguredLanguageCodesInDropdown);
 		assertTrue(oidcClientPage.isArabicLanguageOptionDisplayed(), GlobalConstants.isConfiguredLanguageCodesInDropdown);
+		oidcClientPage.clickOnClientNameLanguageDropdownRow1();
 
 		oidcClientPage.clickOnAddClientNameLanguageButton();
 		oidcClientPage.clickOnClientNameLanguageDropdownRow2();
@@ -106,7 +97,7 @@ public class OidcClientMultilingualFieldsTest extends BaseClass {
 				GlobalConstants.isRow2ExcludesAlreadySelectedLanguage);
 	}
 
-	@Test(priority = 4, description = "Verify Forgot Password / SignUp Banner toggle defaults and info tooltip text")
+	@Test(priority = 4, description = "Verify Forgot Password / SignUp Banner toggle defaults and info tooltip text", dependsOnMethods = "multilingualSectionChecks")
 	public void additionalInfoChecks() {
 		OidcClientPage oidcClientPage = openCreateOidcClientForm();
 
@@ -122,10 +113,7 @@ public class OidcClientMultilingualFieldsTest extends BaseClass {
 				GlobalConstants.isForgotPasswordBannerInfoTooltipCorrect);
 	}
 
-	// Fields are filled in one at a time so each still-incomplete state can confirm Submit stays disabled;
-	// this covers Partner ID / Policy Name / Public Key / Logo URI / Redirect URI mandatory checks in one
-	// pass, plus the Public Key JWK-format rejection along the way.
-	@Test(priority = 5, description = "Verify Submit button stays disabled until every mandatory field is filled")
+	@Test(priority = 5, description = "Verify Submit button stays disabled until every mandatory field is filled", dependsOnMethods = "additionalInfoChecks")
 	public void submitValidationChecks() {
 		OidcClientPage oidcClientPage = openCreateOidcClientForm();
 
@@ -151,10 +139,7 @@ public class OidcClientMultilingualFieldsTest extends BaseClass {
 		assertTrue(oidcClientPage.isSubmitButtonEnabled(), GlobalConstants.isSubmitButtonEnabledAfterFillingForm);
 	}
 
-	// Fills every mandatory and optional field (including a second multilingual name row, first left blank
-	// to confirm Submit disables, then completed), submits, and verifies the resulting confirmation and
-	// list state.
-	@Test(priority = 6, description = "Verify partner can create an OIDC Client with required and optional details")
+	@Test(priority = 6, description = "Verify partner can create an OIDC Client with required and optional details", dependsOnMethods = "submitValidationChecks")
 	public void fillAndSubmitFlow() {
 		OidcClientPage oidcClientPage = openCreateOidcClientForm();
 

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/StatusLabelActiveTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/StatusLabelActiveTest.java
@@ -33,7 +33,6 @@ public class StatusLabelActiveTest extends BaseClass {
 				GlobalConstants.isActiveStatusLabelDisplayed);
 		assertNoActivatedLabel();
 
-		// The status also appears on the details screen, so it is checked there too.
 		partnerAdminPage.clickOnActivatedPartner();
 		assertTrue(partnerAdminPage.isViewPartnersDetailsPageDisplayed(),
 				GlobalConstants.isViewPartnersDetailsPageDisplayed);
@@ -107,14 +106,11 @@ public class StatusLabelActiveTest extends BaseClass {
 		assertNoActivatedLabel();
 	}
 
-	// Exact-text matching, so a legitimate 'Deactivated' badge is never counted here.
 	private void assertNoActivatedLabel() {
 		assertEquals(partnerAdminPage.countElementsWithExactText(GlobalConstants.ACTIVATED_STATUS_LABEL), 0,
 				GlobalConstants.isActivatedStatusLabelAbsent);
 	}
 
-	// The dashboard cards are only reachable from the dashboard itself, so each card
-	// visit starts from a fresh load rather than from whatever page the last one opened.
 	private void returnToDashboard() {
 		driver.get(envPathPmpUiv2);
 	}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/StatusLabelActiveTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/StatusLabelActiveTest.java
@@ -1,0 +1,127 @@
+package io.mosip.testrig.pmpuiv2.testcase;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import io.mosip.testrig.pmpuiv2.pages.DashboardPage;
+import io.mosip.testrig.pmpuiv2.pages.LoginPage;
+import io.mosip.testrig.pmpuiv2.pages.PartnerAdminPage;
+import io.mosip.testrig.pmpuiv2.pages.PoliciesPage;
+import io.mosip.testrig.pmpuiv2.utility.BaseClass;
+import io.mosip.testrig.pmpuiv2.utility.GlobalConstants;
+import io.mosip.testrig.pmpuiv2.utility.LogUtil;
+
+@Test(dependsOnGroups = { "PartnerDetailsTest", "AuthPartnerCreation" }, groups = { "StatusLabelActiveTest" })
+public class StatusLabelActiveTest extends BaseClass {
+
+	private DashboardPage dashboardPage;
+	private PartnerAdminPage partnerAdminPage;
+	private PoliciesPage policiesPage;
+	private LoginPage loginPage;
+
+	@Test(priority = 1, description = "Verify Status updated from Activated to Active for Partner Admins")
+	public void partnerAdminStatusLabelReadsActive() {
+		navigateToPartnerListPage();
+
+		List<String> statuses = partnerAdminPage.getStatusColumnValues();
+		LogUtil.step("Partner list statuses: " + statuses);
+		assertTrue(statuses.contains(GlobalConstants.PARTNER_STATUS_ACTIVE),
+				GlobalConstants.isActiveStatusLabelDisplayed);
+		assertNoActivatedLabel();
+
+		// The status also appears on the details screen, so it is checked there too.
+		partnerAdminPage.clickOnActivatedPartner();
+		assertTrue(partnerAdminPage.isViewPartnersDetailsPageDisplayed(),
+				GlobalConstants.isViewPartnersDetailsPageDisplayed);
+		assertNoActivatedLabel();
+	}
+
+	@Test(priority = 2, description = "Verify Status updated from Activated to Active for Auth Partners")
+	public void authPartnerStatusLabelReadsActive() {
+		dashboardPage = new DashboardPage(driver);
+		partnerAdminPage = new PartnerAdminPage(driver);
+
+		loginAs(GlobalConstants.AUTH_PARTNER_ID);
+
+		policiesPage = dashboardPage.clickOnPoliciesTitle();
+		assertNoActivatedLabel();
+
+		returnToDashboard();
+		dashboardPage.clickOnAuthenticationServicesTitle();
+		assertNoActivatedLabel();
+	}
+
+	@Test(priority = 3, description = "Verify Status updated from Activated to Active for MISP Partners")
+	public void mispPartnerStatusLabelReadsActive() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.clickOnPartnerTypeDropdown();
+		partnerAdminPage.selectPartnerTypeFilterOption(GlobalConstants.MISP_PARTNER);
+		partnerAdminPage.clickOnApplyFiltersBtn();
+
+		List<String> statuses = partnerAdminPage.getStatusColumnValues();
+		LogUtil.step("MISP partner statuses: " + statuses);
+		assertTrue(statuses.contains(GlobalConstants.PARTNER_STATUS_ACTIVE),
+				GlobalConstants.isActiveStatusLabelDisplayed);
+		assertNoActivatedLabel();
+	}
+
+	@Test(priority = 4, description = "Verify Status updated from Activated to Active for Policy Managers")
+	public void policyManagerStatusLabelReadsActive() {
+		dashboardPage = new DashboardPage(driver);
+		partnerAdminPage = new PartnerAdminPage(driver);
+
+		policiesPage = dashboardPage.clickOnPoliciesTitle();
+		assertNoActivatedLabel();
+
+		returnToDashboard();
+		dashboardPage.clickOnPartnerPolicyMappingTab();
+		assertNoActivatedLabel();
+	}
+
+	@Test(priority = 5, description = "Verify Status updated from activated to active in all search dropdown")
+	public void statusSearchDropdownOffersActive() {
+		navigateToPartnerListPage();
+
+		partnerAdminPage.clickOnFilterButton();
+		partnerAdminPage.clickOnStatusFilter();
+
+		assertEquals(partnerAdminPage.getStatusFilterOptionText(1), GlobalConstants.PARTNER_STATUS_ACTIVE,
+				GlobalConstants.isActiveOptionInStatusDropdown);
+		assertNoActivatedLabel();
+	}
+
+	// Exact-text matching, so a legitimate 'Deactivated' badge is never counted here.
+	private void assertNoActivatedLabel() {
+		assertEquals(partnerAdminPage.countElementsWithExactText(GlobalConstants.ACTIVATED_STATUS_LABEL), 0,
+				GlobalConstants.isActivatedStatusLabelAbsent);
+	}
+
+	// The dashboard cards are only reachable from the dashboard itself, so each card
+	// visit starts from a fresh load rather than from whatever page the last one opened.
+	private void returnToDashboard() {
+		driver.get(envPathPmpUiv2);
+	}
+
+	private void loginAs(String userName) {
+		dashboardPage.clickOnProfileDropdown();
+		loginPage = dashboardPage.clickOnLogoutButton();
+		loginPage.login(userName, GlobalConstants.PARTNER_PASSWORD);
+	}
+
+	private void navigateToPartnerListPage() {
+		dashboardPage = new DashboardPage(driver);
+		partnerAdminPage = new PartnerAdminPage(driver);
+
+		assertTrue(dashboardPage.isPartnersDisplayed(), GlobalConstants.isPartnersButtonDisplayed);
+		dashboardPage.clickOnPartners();
+		assertTrue(partnerAdminPage.isSubTitleListDisplayed(), GlobalConstants.isSubTitleListDisplayed);
+		assertTrue(partnerAdminPage.isPartnerListLoaded(), GlobalConstants.isPartnerListLoaded);
+	}
+
+}

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/StatusLabelActiveTest.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/testcase/StatusLabelActiveTest.java
@@ -59,10 +59,19 @@ public class StatusLabelActiveTest extends BaseClass {
 	public void mispPartnerStatusLabelReadsActive() {
 		navigateToPartnerListPage();
 
+		int countBeforeFilter = partnerAdminPage.getFilteredPartnersCountFromSubtitle();
 		partnerAdminPage.clickOnFilterButton();
 		partnerAdminPage.clickOnPartnerTypeDropdown();
 		partnerAdminPage.selectPartnerTypeFilterOption(GlobalConstants.MISP_PARTNER);
 		partnerAdminPage.clickOnApplyFiltersBtn();
+		assertTrue(partnerAdminPage.waitForFilteredCountToChangeFrom(countBeforeFilter),
+				GlobalConstants.isMispPartnerFilterApplied);
+
+		List<String> partnerTypes = partnerAdminPage.getPartnerTypeColumnValues();
+		LogUtil.step("Filtered partner types: " + partnerTypes);
+		for (String partnerType : partnerTypes) {
+			assertEquals(partnerType, GlobalConstants.MISP_PARTNER, GlobalConstants.isFilteredRowPartnerTypeMisp);
+		}
 
 		List<String> statuses = partnerAdminPage.getStatusColumnValues();
 		LogUtil.step("MISP partner statuses: " + statuses);
@@ -75,6 +84,8 @@ public class StatusLabelActiveTest extends BaseClass {
 	public void policyManagerStatusLabelReadsActive() {
 		dashboardPage = new DashboardPage(driver);
 		partnerAdminPage = new PartnerAdminPage(driver);
+
+		loginAs(GlobalConstants.POLICIES_ADMIN);
 
 		policiesPage = dashboardPage.clickOnPoliciesTitle();
 		assertNoActivatedLabel();

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -569,6 +569,41 @@ public class GlobalConstants {
 	public static final String isPolicyAlreadyApprovedMessageDisplayed = "Verify if policy already approved message displayed";
 	public static final String isPolicyPendingForApprovalMessageDisplayed = "Verify if policy pending for approval message displayed";
 	public static final String isOidcClientTabDisplayed = "Verify if oidc client tab displayed";
+	public static final String isPrimaryInformationSectionDisplayed = "Verify if Primary Information section displayed";
+	public static final String isAdditionalInformationSectionDisplayed = "Verify if Additional Information section displayed";
+	public static final String isPrimaryInformationSectionCollapsible = "Verify Primary Information section collapses and expands on click";
+	public static final String isAdditionalInformationSectionCollapsible = "Verify Additional Information section collapses and expands on click";
+	public static final String isSubmitButtonEnabledAfterFillingForm = "Verify submit button is enabled after filling required and optional details";
+	public static final String isRedirectedToOidcClientListAfterSubmit = "Verify partner is redirected to the OIDC Client tab with the list of existing OIDC clients after success";
+	public static final String isNewOidcClientNameAtTopOfList = "Verify newly created OIDC client appears at the top of the list";
+	public static final String isNewOidcClientStatusActive = "Verify newly created OIDC client has status Active";
+	public static final String isPartnerIdFieldLabelDisplayed = "Verify if Partner ID field label displayed";
+	public static final String isPartnerTypeFieldDisplayed = "Verify if Partner Type field displayed";
+	public static final String isPolicyGroupFieldDisplayed = "Verify if Policy Group field displayed";
+	public static final String isPolicyNameFieldLabelDisplayed = "Verify if Policy Name field label displayed";
+	public static final String isOidcClientNameFieldLabelDisplayed = "Verify if OIDC Client Name field label displayed";
+	public static final String isPublicKeyFieldLabelDisplayed = "Verify if Public Key field label displayed";
+	public static final String isLogoUriFieldLabelDisplayed = "Verify if Logo URI field label displayed";
+	public static final String isRedirectUriFieldLabelDisplayed = "Verify if Redirect URI field label displayed";
+	public static final String isGrantTypeFieldLabelDisplayed = "Verify if Grant Type field label displayed";
+	public static final String isSubmitDisabledWhenPartnerIdEmpty = "Verify Submit button is disabled when Partner ID is empty";
+	public static final String isSubmitDisabledWhenPolicyNameEmpty = "Verify Submit button is disabled when Policy Name is empty";
+	public static final String isSubmitDisabledWhenPublicKeyEmpty = "Verify Submit button is disabled when Public Key is empty";
+	public static final String isSubmitDisabledWhenLogoUriEmpty = "Verify Submit button is disabled when Logo URI is empty";
+	public static final String isPublicKeyRejectedForNonJwkFormat = "Verify Public Key field rejects a well-formed key that is not in JWK format";
+	public static final String isSubmitDisabledWhenRedirectUriEmpty = "Verify Submit button is disabled when Redirect URI is empty";
+	public static final String isGrantTypePreSelectedAsAuthorizationCode = "Verify Grant Type is mandatory and pre-selected as Authorization Code";
+	public static final String isGrantTypeNonEditable = "Verify Grant Type remains Authorization Code after attempting to change it";
+	public static final String isMultipleLanguageRowsSupported = "Verify OIDC Client Name supports adding multiple language rows";
+	public static final String isConfiguredLanguageCodesInDropdown = "Verify Language dropdown displays all configured language codes";
+	public static final String isLanguageDropdownDefaultsToEnglish = "Verify Language dropdown defaults to English when a new language row is added";
+	public static final String isAddNewLanguageButtonVisibleAndClickable = "Verify Add New button is visible and clickable in OIDC Client Name (Multilingual Support)";
+	public static final String isRow2ExcludesAlreadySelectedLanguage = "Verify newly added row excludes already selected languages from the dropdown";
+	public static final String isSubmitDisabledWhenLanguageRowTextBlank = "Verify Submit button is disabled when a selected language row's text box is left blank";
+	public static final String isForgotPasswordBannerToggleOnByDefault = "Verify Forgot Password Banner Required toggle is ON by default";
+	public static final String isSignUpBannerToggleOnByDefault = "Verify SignUp Banner Required toggle is ON by default";
+	public static final String isForgotPasswordBannerInfoTooltipCorrect = "Verify info icon tooltip text for Forgot Password Banner Required toggle";
+	public static final String isClientNameLanguageRow1PlaceholderCorrect = "Verify placeholder text for the first OIDC Client Name (Multilingual) row's textbox";
 	public static final String isPublicKeyFormatErrorDisplayed = "Verify if Public key format error displayed";
 	public static final String isInvalidLogoUriErrorDisplayed = "Verify if Logo Uri format error displayed";
 	public static final String isInvalidRedirectUriErrorDisplayed = "Verify if Redirect Uri format error displayed";
@@ -1588,6 +1623,32 @@ public class GlobalConstants {
 	public static final String isPolicyGroupInfoDescriptionDisplayed = "Verify if policy group info description displayed";
 	public static final String isPolicyNameInfoDescriptionDisplayed = "Verify if policy name info description displayed";
 	public static final String isMispLicenseKeyNamePlaceholderDisplayed = "Verify if MISP license key name placeholder displayed";
+	// Save & Publish policy - the draft confirmation screen shown after Save as Draft
+	public static final String DRAFT_CONFIRMATION_POLICY = "draftconfirmpolicy";
+	public static final String DRAFT_CONFIRMATION_POLICY_DESCRIPTION = "policy used to verify the draft confirmation screen";
+	public static final String DRAFT_CONFIRMATION_HEADER = "Policy saved as Draft";
+	// The rendered message names the policy type rather than using the generic wording.
+	public static final String AUTH_POLICY_DRAFT_CONFIRMATION_MESSAGE = "This Authentication Policy is currently in draft mode. You can publish it to make it active, or continue editing if additional modifications are needed by navigating to 'List of Authentication Policies' page";
+	public static final String PUBLISH_BUTTON_LABEL = "Publish";
+	public static final String GO_BACK_BUTTON_LABEL = "Go Back";
+	public static final String isDraftConfirmationHeaderDisplayed = "Verify the draft confirmation screen header is displayed";
+	public static final String isDraftConfirmationMessageCorrect = "Verify the draft confirmation message wording";
+	public static final String isDraftConfirmationPublishButtonDisplayed = "Verify the Publish button is present on the draft confirmation screen";
+	public static final String isDraftConfirmationGoBackButtonDisplayed = "Verify the Go Back button is present on the draft confirmation screen";
+	public static final String isPublishButtonOnLeftOfGoBack = "Verify Publish is placed to the left of Go Back";
+	public static final String isRedirectedToPolicyListAfterGoBack = "Verify Go Back returns to the list of policies";
+	public static final String isPublishInitiatedFromDraftConfirmation = "Verify Publish from the draft confirmation screen starts the publish flow";
+
+	// Multiple MISP license keys - the Important Note shown on the Generate MISP License Key screen
+	public static final String MISP_LICENSE_KEY_IMPORTANT_NOTE = "Important Note: If multiple MISP license keys are generated for the same Partner ID, only the latest MISP license key will remain active in the ID Authentication (IDA) module. Older license keys will be overwritten. Please exercise caution when creating multiple license keys for the same Partner.";
+	public static final String IMPORTANT_NOTE_EDIT_ATTEMPT = "automation edit attempt";
+	public static final String isImportantNoteTextCorrect = "Verify the Important Note displays the multiple license keys wording";
+	public static final String isImportantNoteReadOnly = "Verify the Important Note text cannot be edited";
+	public static final String isImportantNoteNotFocusable = "Verify the Important Note does not take keyboard focus";
+	public static final String isImportantNoteFullyVisible = "Verify the Important Note is fully visible within the viewport";
+	public static final String isImportantNoteNotCovered = "Verify the Important Note is not covered by any other element";
+	public static final String isImportantNoteNotOverlappingFormFields = "Verify the Important Note does not overlap the form fields or buttons";
+
 	public static final String isMispLicenseKeyGuidenceNoteDisplayed = "Verify if MISP license key guidence note displayed";
 	public static final String isMispLicenseKeyGuidenceNoteNotEditable = "Verify if MISP license key guidence note not editable";
 	public static final String isMispLicenseKeyImportantNoteDisplayed = "Verify if MISP license key important note displayed";
@@ -1694,5 +1755,13 @@ public class GlobalConstants {
 	public static final String EMAIL_ADDRESS_FILTER_INFO_TOOLTIP = "Note: This filter performs an exact match. Please enter the full email address (e.g., user@example.com) to find results.";
 	public static final String isEmailAddressFilterInfoIconDisplayed = "Verify the info icon is displayed alongside the email address filter textbox";
 	public static final String isEmailAddressFilterInfoTooltipCorrect = "Verify the info icon tooltip displays the exact match guidance text";
+
+	// Status label rename - the old 'Activated' wording is replaced by 'Active' across the PMS UI.
+	// Unrelated to 'Inactive' (certificate not uploaded) and 'Deactivated' (partner deactivated),
+	// which are separate statuses and keep their wording.
+	public static final String ACTIVATED_STATUS_LABEL = "Activated";
+	public static final String isActiveStatusLabelDisplayed = "Verify the status label reads Active";
+	public static final String isActivatedStatusLabelAbsent = "Verify the old Activated status label does not appear anywhere on the page";
+	public static final String isActiveOptionInStatusDropdown = "Verify the status search dropdown offers Active instead of Activated";
 
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -1623,11 +1623,9 @@ public class GlobalConstants {
 	public static final String isPolicyGroupInfoDescriptionDisplayed = "Verify if policy group info description displayed";
 	public static final String isPolicyNameInfoDescriptionDisplayed = "Verify if policy name info description displayed";
 	public static final String isMispLicenseKeyNamePlaceholderDisplayed = "Verify if MISP license key name placeholder displayed";
-	// Save & Publish policy - the draft confirmation screen shown after Save as Draft
 	public static final String DRAFT_CONFIRMATION_POLICY = "draftconfirmpolicy";
 	public static final String DRAFT_CONFIRMATION_POLICY_DESCRIPTION = "policy used to verify the draft confirmation screen";
 	public static final String DRAFT_CONFIRMATION_HEADER = "Policy saved as Draft";
-	// The rendered message names the policy type rather than using the generic wording.
 	public static final String AUTH_POLICY_DRAFT_CONFIRMATION_MESSAGE = "This Authentication Policy is currently in draft mode. You can publish it to make it active, or continue editing if additional modifications are needed by navigating to 'List of Authentication Policies' page";
 	public static final String PUBLISH_BUTTON_LABEL = "Publish";
 	public static final String GO_BACK_BUTTON_LABEL = "Go Back";
@@ -1639,7 +1637,6 @@ public class GlobalConstants {
 	public static final String isRedirectedToPolicyListAfterGoBack = "Verify Go Back returns to the list of policies";
 	public static final String isPublishInitiatedFromDraftConfirmation = "Verify Publish from the draft confirmation screen starts the publish flow";
 
-	// Multiple MISP license keys - the Important Note shown on the Generate MISP License Key screen
 	public static final String MISP_LICENSE_KEY_IMPORTANT_NOTE = "Important Note: If multiple MISP license keys are generated for the same Partner ID, only the latest MISP license key will remain active in the ID Authentication (IDA) module. Older license keys will be overwritten. Please exercise caution when creating multiple license keys for the same Partner.";
 	public static final String IMPORTANT_NOTE_EDIT_ATTEMPT = "automation edit attempt";
 	public static final String isImportantNoteTextCorrect = "Verify the Important Note displays the multiple license keys wording";
@@ -1756,9 +1753,6 @@ public class GlobalConstants {
 	public static final String isEmailAddressFilterInfoIconDisplayed = "Verify the info icon is displayed alongside the email address filter textbox";
 	public static final String isEmailAddressFilterInfoTooltipCorrect = "Verify the info icon tooltip displays the exact match guidance text";
 
-	// Status label rename - the old 'Activated' wording is replaced by 'Active' across the PMS UI.
-	// Unrelated to 'Inactive' (certificate not uploaded) and 'Deactivated' (partner deactivated),
-	// which are separate statuses and keep their wording.
 	public static final String ACTIVATED_STATUS_LABEL = "Activated";
 	public static final String isActiveStatusLabelDisplayed = "Verify the status label reads Active";
 	public static final String isActivatedStatusLabelAbsent = "Verify the old Activated status label does not appear anywhere on the page";

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/GlobalConstants.java
@@ -1763,5 +1763,7 @@ public class GlobalConstants {
 	public static final String isActiveStatusLabelDisplayed = "Verify the status label reads Active";
 	public static final String isActivatedStatusLabelAbsent = "Verify the old Activated status label does not appear anywhere on the page";
 	public static final String isActiveOptionInStatusDropdown = "Verify the status search dropdown offers Active instead of Activated";
+	public static final String isMispPartnerFilterApplied = "Verify the MISP Partner type filter has been applied before reading statuses";
+	public static final String isFilteredRowPartnerTypeMisp = "Verify every filtered row's Partner Type is MISP Partner";
 
 }

--- a/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/TestRunner.java
+++ b/uitest-pmp-v2/src/main/java/io/mosip/testrig/pmpuiv2/utility/TestRunner.java
@@ -70,6 +70,8 @@ public class TestRunner {
 					"io.mosip.testrig.pmpuiv2.testcase.PolicyCreationForAuthPartner");
 			XmlClass oidcClientAuthPartnerTest = new XmlClass(
 					"io.mosip.testrig.pmpuiv2.testcase.OidcClientAuthPartnerTest");
+			XmlClass oidcClientMultilingualFieldsTest = new XmlClass(
+					"io.mosip.testrig.pmpuiv2.testcase.OidcClientMultilingualFieldsTest");
 			XmlClass deviceCreationTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.DeviceCreationTest");
 			XmlClass policyGroupTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PolicyGroupTest");
 			XmlClass certificateTrustStoreTest = new XmlClass(
@@ -82,6 +84,9 @@ public class TestRunner {
 			XmlClass partnerDetailsTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PartnerDetailsTest");
 			XmlClass partnerFilterTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PartnerFilterTest");
 			XmlClass partnerEmailFilterTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.PartnerEmailFilterTest");
+			XmlClass statusLabelActiveTest = new XmlClass("io.mosip.testrig.pmpuiv2.testcase.StatusLabelActiveTest");
+			XmlClass draftConfirmationScreenTest = new XmlClass(
+					"io.mosip.testrig.pmpuiv2.testcase.DraftConfirmationScreenTest");
 			XmlClass partnerDeactivateOptionTest = new XmlClass(
 					"io.mosip.testrig.pmpuiv2.testcase.PartnerDeactivateOptionTest");
 			XmlClass partnerDeactivatedPortalTest = new XmlClass(
@@ -148,9 +153,17 @@ public class TestRunner {
 					addClassIfAbsent(classes, partnerAdminCreation, authPartnerCreation, policyCreationForAuthPartner,
 							oidcClientAuthPartnerTest);
 					break;
+				case "OidcClientMultilingualFieldsTest":
+					addClassIfAbsent(classes, partnerAdminCreation, authPartnerCreation, policyCreationForAuthPartner,
+							oidcClientMultilingualFieldsTest);
+					break;
 				case "DeviceCreationTest":
 					addClassIfAbsent(classes, partnerAdminCreation, devicePartnerCreation, sbiCreationTest,
 							deviceCreationTest);
+					break;
+				case "DraftConfirmationScreenTest":
+					addClassIfAbsent(classes, partnerAdminCreation, policyAdminAndPartnerCreation, policyGroupTest,
+							draftConfirmationScreenTest);
 					break;
 				case "PolicyGroupTest":
 					addClassIfAbsent(classes, partnerAdminCreation, policyAdminAndPartnerCreation, policyGroupTest);
@@ -188,6 +201,10 @@ public class TestRunner {
 				case "PartnerEmailFilterTest":
 					addClassIfAbsent(classes, partnerAdminCreation, deactivatePartnerCreation, partnerDetailsTest,
 							partnerEmailFilterTest);
+					break;
+				case "StatusLabelActiveTest":
+					addClassIfAbsent(classes, partnerAdminCreation, authPartnerCreation, deactivatePartnerCreation,
+							partnerDetailsTest, statusLabelActiveTest);
 					break;
 				case "PartnerDeactivateOptionTest":
 					addClassIfAbsent(classes, partnerAdminCreation, deactivatePartnerCreation, partnerDetailsTest,

--- a/uitest-pmp-v2/src/main/resources/testngFile/testng.xml
+++ b/uitest-pmp-v2/src/main/resources/testngFile/testng.xml
@@ -20,6 +20,7 @@
 			<class name="io.mosip.testrig.pmpuiv2.testcase.AuthPartnerCreation" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PolicyCreationForAuthPartner" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.OidcClientAuthPartnerTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.OidcClientMultilingualFieldsTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.ApiKeyAuthPartnerTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.AuthPartnerWithoutCertificateTest" />
 			<!--DEVICE PARTNER FLOW-->
@@ -35,6 +36,7 @@
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PolicyGroupTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.DatasharePolicyTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.AuthPolicyTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.DraftConfirmationScreenTest" />
 			<!--MISP PARTNER FLOW-->
 			<class name="io.mosip.testrig.pmpuiv2.testcase.MispPartnerTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.MispPolicyTest" />
@@ -45,6 +47,7 @@
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerDetailsTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerFilterTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerEmailFilterTest" />
+			<class name="io.mosip.testrig.pmpuiv2.testcase.StatusLabelActiveTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerDeactivateOptionTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.PartnerDeactivatedPortalTest" />
 			<class name="io.mosip.testrig.pmpuiv2.testcase.DeactivatePartner2Creation" />


### PR DESCRIPTION
## Description

Automates the **Create OIDC Client Partner Enhancement to Support Multilingual Fields and Additional Information** story, plus includes prior separate WIP for a few other scenarios.

### OidcClientMultilingualFieldsTest (new)

Covers the Create OIDC Client form's:
- Primary/Additional Information sections (two-section layout, collapse/expand)
- All existing field labels displayed correctly
- Grant Type: mandatory, pre-selected as "Authorization Code", non-editable
- Mandatory-field validation: Submit stays disabled until Partner ID, Policy Name, Public Key, Logo URI, and Redirect URI are all filled
- Public Key rejects a well-formed non-JWK key (PEM), not just malformed text
- OIDC Client Name (Multilingual Support): Add New row, language dropdown options (English/Français/العربية), defaults to English, row 2 excludes already-selected languages, placeholder text, blank text disables Submit
- Additional Information: Forgot Password / SignUp Banner toggles ON by default, info-icon tooltip text
- Full create flow: fills all fields (including a second multilingual name row), submits, and verifies the new client appears at the top of the list with Active status